### PR TITLE
Add prisma client stubs for tests

### DIFF
--- a/generated/client/index.d.ts
+++ b/generated/client/index.d.ts
@@ -1,0 +1,45 @@
+export enum RelationshipMetadataKey {
+  REASON = 'REASON',
+  TYPE = 'TYPE',
+  DESCRIPTION = 'DESCRIPTION',
+}
+
+export enum QuestionType {
+  selection = 'selection',
+  value = 'value',
+  void = 'void',
+}
+
+export enum QuestionValidationStatus {
+  ai_generated = 'ai_generated',
+  in_manual_review = 'in_manual_review',
+  approved = 'approved',
+  rejected = 'rejected',
+}
+
+export enum Units {
+  meter = 'meter',
+  kilogram = 'kilogram',
+  second = 'second',
+  ampere = 'ampere',
+  kelvin = 'kelvin',
+  mole = 'mole',
+  candela = 'candela',
+}
+
+export enum LearningResourceType {
+  video = 'video',
+}
+
+export const Prisma: {
+  RelationshipMetadataKey: typeof RelationshipMetadataKey;
+  QuestionType: typeof QuestionType;
+  QuestionValidationStatus: typeof QuestionValidationStatus;
+  Units: typeof Units;
+  LearningResourceType: typeof LearningResourceType;
+};
+
+export class PrismaClient {
+  $connect(): Promise<void>;
+  $disconnect(): Promise<void>;
+}

--- a/generated/client/index.ts
+++ b/generated/client/index.ts
@@ -1,0 +1,49 @@
+export enum RelationshipMetadataKey {
+  REASON = 'REASON',
+  TYPE = 'TYPE',
+  DESCRIPTION = 'DESCRIPTION',
+}
+
+export enum QuestionType {
+  selection = 'selection',
+  value = 'value',
+  void = 'void',
+}
+
+export enum QuestionValidationStatus {
+  ai_generated = 'ai_generated',
+  in_manual_review = 'in_manual_review',
+  approved = 'approved',
+  rejected = 'rejected',
+}
+
+export enum Units {
+  meter = 'meter',
+  kilogram = 'kilogram',
+  second = 'second',
+  ampere = 'ampere',
+  kelvin = 'kelvin',
+  mole = 'mole',
+  candela = 'candela',
+}
+
+export enum LearningResourceType {
+  video = 'video',
+}
+
+export const Prisma = {
+  RelationshipMetadataKey,
+  QuestionType,
+  QuestionValidationStatus,
+  Units,
+  LearningResourceType,
+};
+
+export class PrismaClient {
+  async $connect(): Promise<void> {
+    return Promise.resolve();
+  }
+  async $disconnect(): Promise<void> {
+    return Promise.resolve();
+  }
+}


### PR DESCRIPTION
## Summary
- add lightweight stubs for generated Prisma client

## Testing
- `pnpm format` *(fails: No files matching the pattern were found)*
- `pnpm lint` *(fails: pnpm tried to run generate and failed)*
- `pnpm test:seed` *(fails: vitest not found)*
- `pnpm build` *(fails: pnpm attempted to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888ed8f84d88332b09b853dfbdd35ec