### PR TITLE
Add Pascal Triangle and Binomial Formula modules

### DIFF
--- a/prisma/seed/modules.seed.ts
+++ b/prisma/seed/modules.seed.ts
@@ -62,6 +62,8 @@ export const seedModules = async (
       Permutations: 'b046c3a7-4e8f-4571-a015-0a7cc33daca2',
       'Combinations with Repetitions': 'e289a3c2-6d14-479d-89e6-a83b56e08287',
       'Permutations with Repetitions': 'e7c5b81e-5aad-4715-ab5d-c08122c05ef1',
+      'Pascal Triangle': '453489f6-61fa-4699-b275-26d6165dbc89',
+      'Binomial Formula': 'ee3583e5-7114-4a42-8a78-c1cb689276c9',
     };
     return translationMap[moduleText] || '';
   };
@@ -113,6 +115,8 @@ export const seedModules = async (
     Permutations: 'c6dd59ac-1802-4bc9-b91e-ca77bb32620e',
     'Combinations with Repetitions': '87a1da94-793c-4565-8706-8fd073a50cf6',
     'Permutations with Repetitions': 'f2866b62-f4f6-4e22-8fcc-f4bd8bbdb275',
+    'Pascal Triangle': '82da973e-a84a-44f4-b33f-bcf907961eb3',
+    'Binomial Formula': 'e1367766-2b1a-42f9-a725-58d092bbc080',
   };
 
   const modules = [
@@ -263,6 +267,18 @@ export const seedModules = async (
     {
       en_text: 'Multiplication Principle',
       he_text: 'עקרון הכפל',
+      parent: 'Combinatorics',
+      course: 'Discrete Mathematics',
+    },
+    {
+      en_text: 'Pascal Triangle',
+      he_text: 'משולש פסקל',
+      parent: 'Combinatorics',
+      course: 'Discrete Mathematics',
+    },
+    {
+      en_text: 'Binomial Formula',
+      he_text: 'נוסחת הבינום',
       parent: 'Combinatorics',
       course: 'Discrete Mathematics',
     },


### PR DESCRIPTION
## Summary
- extend modules seed with Pascal Triangle and Binomial Formula
- set them as Combinatorics submodules

## Testing
- `npx prettier --write prisma/seed/modules.seed.ts`
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_688a443fccc083329700bc6b9d11d6c7