### PR TITLE
feat(seed): add mathematical recursion submodule

### DIFF
--- a/prisma/seed/modules.seed.ts
+++ b/prisma/seed/modules.seed.ts
@@ -89,6 +89,7 @@ export const seedModules = async (
       'Binomial Formula': 'ee3583e5-7114-4a42-8a78-c1cb689276c9',
       'Inclusion Principle': '4f5a6b7c-8d9e-4012-a456-789abc123def',
       'Separation Principle': '5a6b7c8d-9e0f-4123-b567-89abcd234eff',
+      'Mathematical Recursion': '31b7ef41-3b67-4181-ba4d-c6170399a6d9',
       'Introduction to Logic': '1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d',
       'Basic Logic Concepts': '2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e',
       'Logical Operators': '3c4d5e6f-7a8b-4c9d-a0ef-2a3b4c5d6e7f',
@@ -151,6 +152,7 @@ export const seedModules = async (
     'Binomial Formula': 'e1367766-2b1a-42f9-a725-58d092bbc080',
     'Inclusion Principle': '4f5a6b7c-8d9e-4012-a456-789abc123def',
     'Separation Principle': '5a6b7c8d-9e0f-4123-b567-89abcd234eff',
+    'Mathematical Recursion': '37d15e78-fcf2-49a0-bbde-b4dbffd904a7',
     'Introduction to Logic': '3f2e1d4c-5b6a-4789-8c0d-1e2f3a4b5c6d',
     'Basic Logic Concepts': '8b9c0d1e-2f3a-4b5c-86de-8f9a0b1c2d3e',
     'Logical Operators': '9c0d1e2f-3a4b-4c6d-87ef-9a0b1c2d3e4f',
@@ -379,6 +381,12 @@ export const seedModules = async (
     {
       en_text: 'Separation Principle',
       he_text: 'עקרון ההפרדה',
+      parent: 'Combinatorics',
+      course: 'Discrete Mathematics',
+    },
+    {
+      en_text: 'Mathematical Recursion',
+      he_text: 'רקורסיה מטמטית',
       parent: 'Combinatorics',
       course: 'Discrete Mathematics',
     },


### PR DESCRIPTION
## Summary
- seed deterministic translation and module IDs for Mathematical Recursion
- include Mathematical Recursion as a Combinatorics submodule in seed data

## Testing
- `pnpm format` *(fails: No files matching the pattern were found: "test/**/*.ts")*
- `pnpm lint` *(fails: Unsafe assignment of an `any` value in blocks.service.spec.ts)*
- `pnpm test` *(fails: Snapshot mismatched; multiple test failures)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688cf4228278833283a99d6fd8b475bf