### PR TITLE
feat: add graphql for degrees queries

### DIFF
--- a/src/modules/degrees/degrees.module.ts
+++ b/src/modules/degrees/degrees.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { DegreesService } from './degrees.service';
 import { DegreesController } from './degrees.controller';
 import { PrismaModule } from '../../prisma/prisma.module';
+import { DegreesResolver } from './degrees.resolver';
 
 @Module({
   imports: [PrismaModule],
   controllers: [DegreesController],
-  providers: [DegreesService],
+  providers: [DegreesService, DegreesResolver],
   exports: [DegreesService],
 })
 export class DegreesModule {}

--- a/src/modules/degrees/degrees.resolver.spec.ts
+++ b/src/modules/degrees/degrees.resolver.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DegreesResolver } from './degrees.resolver';
+import { DegreesService } from './degrees.service';
+import { Degree } from './models/Degree.entity';
+
+describe('DegreesResolver', () => {
+  let resolver: DegreesResolver;
+  let mock: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    mock = {
+      findAll: vi.fn(),
+      findUnique: vi.fn(),
+      findByUniversityId: vi.fn(),
+      findByUniversityIdAndDisciplineId: vi.fn(),
+    };
+    resolver = new DegreesResolver(mock as unknown as DegreesService);
+  });
+
+  it('returns degrees', async () => {
+    const degrees = [{ id: '1' }] as Degree[];
+    mock.findAll.mockResolvedValue(degrees);
+    expect(await resolver.getDegrees()).toEqual(degrees);
+  });
+
+  it('returns a degree or null', async () => {
+    const degree = { id: '1' } as Degree;
+    mock.findUnique.mockResolvedValue(degree);
+    expect(await resolver.getDegree('1')).toEqual(degree);
+    mock.findUnique.mockResolvedValue(null);
+    expect(await resolver.getDegree('missing')).toBeNull();
+  });
+
+  it('returns degrees by filters', async () => {
+    const degrees = [{ id: '1' }] as Degree[];
+    mock.findByUniversityId.mockResolvedValue(degrees);
+    expect(await resolver.getDegreesByUniversity('u1')).toEqual(degrees);
+    mock.findByUniversityIdAndDisciplineId.mockResolvedValue(degrees);
+    expect(
+      await resolver.getDegreesByUniversityAndDiscipline('u1', 'd1'),
+    ).toEqual(degrees);
+  });
+});

--- a/src/modules/degrees/degrees.resolver.ts
+++ b/src/modules/degrees/degrees.resolver.ts
@@ -1,0 +1,38 @@
+import { Resolver, Query, Args, ID } from '@nestjs/graphql';
+import { DegreesService } from './degrees.service';
+import { Degree } from './models/Degree.entity';
+
+@Resolver(() => Degree)
+export class DegreesResolver {
+  constructor(private readonly degreesService: DegreesService) {}
+
+  @Query(() => [Degree], { name: 'degrees' })
+  async getDegrees(): Promise<Degree[]> {
+    return this.degreesService.findAll();
+  }
+
+  @Query(() => Degree, { name: 'degree', nullable: true })
+  async getDegree(
+    @Args('id', { type: () => ID }) id: string,
+  ): Promise<Degree | null> {
+    return this.degreesService.findUnique(id);
+  }
+
+  @Query(() => [Degree], { name: 'degreesByUniversity' })
+  async getDegreesByUniversity(
+    @Args('universityId', { type: () => ID }) universityId: string,
+  ): Promise<Degree[]> {
+    return this.degreesService.findByUniversityId(universityId);
+  }
+
+  @Query(() => [Degree], { name: 'degreesByUniversityAndDiscipline' })
+  async getDegreesByUniversityAndDiscipline(
+    @Args('universityId', { type: () => ID }) universityId: string,
+    @Args('disciplineId', { type: () => ID }) disciplineId: string,
+  ): Promise<Degree[]> {
+    return this.degreesService.findByUniversityIdAndDisciplineId(
+      universityId,
+      disciplineId,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- expose degrees via GraphQL queries
- cover new resolver with unit tests

## Testing
- `pnpm format` *(fails: No files matching the pattern were found: "test/**/*.ts".)*
- `pnpm lint` *(fails: Unsafe assignment of an error typed value)*
- `npx eslint src/modules/degrees/**/*.ts --max-warnings=0`
- `pnpm test` *(fails: Snapshot `seed snapshot > saves seeded data snapshot 1` mismatched)*
- `npx vitest run src/modules/degrees/degrees.resolver.spec.ts`
- `pnpm build` *(fails: Property 'moduleIds' does not exist on type 'QuestionsQueryDto'...)*

------
https://chatgpt.com/codex/tasks/task_e_688dd8eafae08332b181daec75c047ea