### PR TITLE
feat: add additional modules

### DIFF
--- a/prisma/seed/__snapshots__/seed.snapshot.spec.ts.snap
+++ b/prisma/seed/__snapshots__/seed.snapshot.spec.ts.snap
@@ -1118,6 +1118,21 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
     {
       "id": "70bf7dc6-cbb8-4f2e-b2e3-1736586c7d9d",
     },
+    {
+      "id": "4a360125-e963-4c2b-88a8-d86aee59d8bc",
+    },
+    {
+      "id": "b4de3329-f3af-4ae9-b67d-bf1c5d1a30fb",
+    },
+    {
+      "id": "97128d23-40d6-4045-a57d-ec1b08c3723e",
+    },
+    {
+      "id": "f27c282a-0396-432d-8c9f-472233089edd",
+    },
+    {
+      "id": "9a45204a-d855-4558-b187-bb136002a9bb",
+    },
   ],
   "blockRelationship": [
     {
@@ -2231,6 +2246,31 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "blockId": "70bf7dc6-cbb8-4f2e-b2e3-1736586c7d9d",
       "id": "70bf7dc6-cbb8-4f2e-b2e3-1736586c7d9d",
       "translationId": "f5f24066-f9e1-4087-9d6a-598042cb0d2b",
+    },
+    {
+      "blockId": "4a360125-e963-4c2b-88a8-d86aee59d8bc",
+      "id": "4a360125-e963-4c2b-88a8-d86aee59d8bc",
+      "translationId": "f0557643-39f1-41d8-b4bd-14d5242e7102",
+    },
+    {
+      "blockId": "b4de3329-f3af-4ae9-b67d-bf1c5d1a30fb",
+      "id": "b4de3329-f3af-4ae9-b67d-bf1c5d1a30fb",
+      "translationId": "593afff3-cf87-4c67-b80d-ae06ffd4c829",
+    },
+    {
+      "blockId": "97128d23-40d6-4045-a57d-ec1b08c3723e",
+      "id": "97128d23-40d6-4045-a57d-ec1b08c3723e",
+      "translationId": "7cb38204-869c-47a9-a2a2-a72020e7bdee",
+    },
+    {
+      "blockId": "f27c282a-0396-432d-8c9f-472233089edd",
+      "id": "f27c282a-0396-432d-8c9f-472233089edd",
+      "translationId": "dd9aa8c9-b413-42f9-b26a-194a2ef2f4d0",
+    },
+    {
+      "blockId": "9a45204a-d855-4558-b187-bb136002a9bb",
+      "id": "9a45204a-d855-4558-b187-bb136002a9bb",
+      "translationId": "1bf61cb6-9d5f-4fa8-9565-27fbdf4a1a18",
     },
   ],
   "numberAnswer": [
@@ -5753,6 +5793,31 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "en_text": "Min Max Algorithm",
       "he_text": "אלגוריתם מינ-מקס",
       "id": "f5f24066-f9e1-4087-9d6a-598042cb0d2b",
+    },
+    {
+      "en_text": "Limits and Continuity",
+      "he_text": "גבולות ורציפות",
+      "id": "f0557643-39f1-41d8-b4bd-14d5242e7102",
+    },
+    {
+      "en_text": "Differentiation Techniques",
+      "he_text": "שיטות גזירה",
+      "id": "593afff3-cf87-4c67-b80d-ae06ffd4c829",
+    },
+    {
+      "en_text": "Integration by Parts",
+      "he_text": "אינטגרציה בחלקים",
+      "id": "7cb38204-869c-47a9-a2a2-a72020e7bdee",
+    },
+    {
+      "en_text": "Graph Traversal Algorithms",
+      "he_text": "אלגוריתמים למעבר על גרפים",
+      "id": "dd9aa8c9-b413-42f9-b26a-194a2ef2f4d0",
+    },
+    {
+      "en_text": "Neural Networks Fundamentals",
+      "he_text": "יסודות רשתות נוירונים",
+      "id": "1bf61cb6-9d5f-4fa8-9565-27fbdf4a1a18",
     },
     {
       "en_text": "Combinations with Repetitions",

--- a/prisma/seed/modules.seed.ts
+++ b/prisma/seed/modules.seed.ts
@@ -114,6 +114,11 @@ export const seedModules = async (
         '4b6c8d1e-3f5a-4d7b-af8c-5e9f1a2b3c4d',
       'Upper Sums': 'f8a1e3d5-6b9c-4f2a-8e1f-3a5c7d9e2b4f',
       'Lower Sums': '2c4e6a8f-1d3f-4a7c-9e2a-5f8a1c3e6d9f',
+      'Limits and Continuity': 'f0557643-39f1-41d8-b4bd-14d5242e7102',
+      'Differentiation Techniques': '593afff3-cf87-4c67-b80d-ae06ffd4c829',
+      'Integration by Parts': '7cb38204-869c-47a9-a2a2-a72020e7bdee',
+      'Graph Traversal Algorithms': 'dd9aa8c9-b413-42f9-b26a-194a2ef2f4d0',
+      'Neural Networks Fundamentals': '1bf61cb6-9d5f-4fa8-9565-27fbdf4a1a18',
     };
     return translationMap[moduleText] || '';
   };
@@ -187,6 +192,11 @@ export const seedModules = async (
     'Logic Gates': '1e2f3a4b-5c6d-4e8f-a9ab-1c2d3e4f5a6b',
     'Conditional Statements': '2f3a4b5c-6d7e-4f9a-a0bc-2d3e4f5a6b7c',
     'Logical Equivalence': '3a4b5c6d-7e8f-409b-a1cd-3e4f5a6b7c8d',
+    'Limits and Continuity': '4a360125-e963-4c2b-88a8-d86aee59d8bc',
+    'Differentiation Techniques': 'b4de3329-f3af-4ae9-b67d-bf1c5d1a30fb',
+    'Integration by Parts': '97128d23-40d6-4045-a57d-ec1b08c3723e',
+    'Graph Traversal Algorithms': 'f27c282a-0396-432d-8c9f-472233089edd',
+    'Neural Networks Fundamentals': '9a45204a-d855-4558-b187-bb136002a9bb',
   };
 
   const modules = [
@@ -597,6 +607,31 @@ export const seedModules = async (
     {
       en_text: 'Min Max Algorithm',
       he_text: 'אלגוריתם מינ-מקס',
+      course: 'Artificial Intelligence',
+    },
+    {
+      en_text: 'Limits and Continuity',
+      he_text: 'גבולות ורציפות',
+      courses: ['Calculus A', 'Infinitesimal Calculus 1'],
+    },
+    {
+      en_text: 'Differentiation Techniques',
+      he_text: 'שיטות גזירה',
+      courses: ['Calculus A', 'Calculus B'],
+    },
+    {
+      en_text: 'Integration by Parts',
+      he_text: 'אינטגרציה בחלקים',
+      course: 'Calculus B',
+    },
+    {
+      en_text: 'Graph Traversal Algorithms',
+      he_text: 'אלגוריתמים למעבר על גרפים',
+      course: 'Data Structures and Introduction to Algorithms',
+    },
+    {
+      en_text: 'Neural Networks Fundamentals',
+      he_text: 'יסודות רשתות נוירונים',
       course: 'Artificial Intelligence',
     },
   ];

--- a/prisma/seed/translations.consts.ts
+++ b/prisma/seed/translations.consts.ts
@@ -1320,6 +1320,31 @@ export const TRANSLATIONS: TranslationSeed[] = [
     he_text: 'אלגוריתם מינ-מקס',
   },
   {
+    id: 'f0557643-39f1-41d8-b4bd-14d5242e7102',
+    en_text: 'Limits and Continuity',
+    he_text: 'גבולות ורציפות',
+  },
+  {
+    id: '593afff3-cf87-4c67-b80d-ae06ffd4c829',
+    en_text: 'Differentiation Techniques',
+    he_text: 'שיטות גזירה',
+  },
+  {
+    id: '7cb38204-869c-47a9-a2a2-a72020e7bdee',
+    en_text: 'Integration by Parts',
+    he_text: 'אינטגרציה בחלקים',
+  },
+  {
+    id: 'dd9aa8c9-b413-42f9-b26a-194a2ef2f4d0',
+    en_text: 'Graph Traversal Algorithms',
+    he_text: 'אלגוריתמים למעבר על גרפים',
+  },
+  {
+    id: '1bf61cb6-9d5f-4fa8-9565-27fbdf4a1a18',
+    en_text: 'Neural Networks Fundamentals',
+    he_text: 'יסודות רשתות נוירונים',
+  },
+  {
     id: 'e289a3c2-6d14-479d-89e6-a83b56e08287',
     en_text: 'Combinations with Repetitions',
     he_text: 'חליפות עם חזרות',


### PR DESCRIPTION
## Summary
- expand module seeding with new math and CS topics
- register translations for newly added modules
- refresh seed snapshot

## Testing
- `pnpm exec prettier prisma/seed/modules.seed.ts --write`
- `pnpm format` (fails: No files matching the pattern were found: "test/**/*.ts")
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689391580a808332a5dbcb10d781b00e