### PR TITLE
feat: expand math modules with probability and series

### DIFF
--- a/prisma/seed/__snapshots__/seed.snapshot.spec.ts.snap
+++ b/prisma/seed/__snapshots__/seed.snapshot.spec.ts.snap
@@ -716,6 +716,246 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "questionId": "de8d4330-0e4f-440c-874a-58a63441b07d",
     },
     {
+      "id": "f29268fd-8d42-4d79-8a57-495558a888b6",
+      "questionId": "52c4d70d-5b41-40eb-841a-d655bee0ded0",
+    },
+    {
+      "id": "b241bfc1-748f-4775-b4a9-fa10d2eccac2",
+      "questionId": "e52169d0-cba2-4889-b327-3a2f610df34f",
+    },
+    {
+      "id": "63556833-7bac-4e95-871d-bf8e144f4884",
+      "questionId": "4817954c-91ff-460d-a69b-a50507781d48",
+    },
+    {
+      "id": "e3e85d47-8d35-4521-b507-c81d5bb579e9",
+      "questionId": "3ed9edf5-6783-4a6c-8421-5b6e39f4416e",
+    },
+    {
+      "id": "4f6ca6ae-c225-4f08-bc06-5ada7cf659b5",
+      "questionId": "9da9bb06-7c47-49e0-8e5f-2d705b8e0c65",
+    },
+    {
+      "id": "e5142250-326f-4d55-b8e4-86dcdc45af64",
+      "questionId": "96d606d2-95d4-42bf-b6bd-40e20deea584",
+    },
+    {
+      "id": "194dbc1b-0029-42b3-9423-1e48c4da3a67",
+      "questionId": "055356ae-1862-4150-8b82-2f53f3abd864",
+    },
+    {
+      "id": "011ab3ff-8455-417c-89e7-98b5253ea4c6",
+      "questionId": "fb6d6ef9-dd8e-4e77-969d-bbe4b2c65a8a",
+    },
+    {
+      "id": "1f0b8cd6-881b-4448-b5cb-880a85d88006",
+      "questionId": "8ddfb44e-b729-4d52-946b-ccef0fdc7639",
+    },
+    {
+      "id": "2b17eb29-dca2-4d32-8459-b5df2b60a24f",
+      "questionId": "08eb3b54-0990-4767-a1bc-f06af3845a4b",
+    },
+    {
+      "id": "db579826-aa94-49ac-ade8-f6ec932b5cb6",
+      "questionId": "abebb16a-625f-46bc-86f7-8d62b26a0068",
+    },
+    {
+      "id": "b257b4b2-1f59-4928-8672-42c8c71ca6d3",
+      "questionId": "6418770c-9dc3-46fe-a975-c9cf96a1e6e1",
+    },
+    {
+      "id": "08fe5e6c-4385-4bea-8b5d-ef579b879823",
+      "questionId": "0f2a875a-76ae-4d97-af58-6ad023ca5097",
+    },
+    {
+      "id": "0dfe6ced-c9d8-48a7-bd07-62b5ae1a05ba",
+      "questionId": "ce287b90-6484-4619-b3e0-96c3a9a246c0",
+    },
+    {
+      "id": "450c2f52-703a-488e-b0a1-b162d1e765c6",
+      "questionId": "2343d8a5-264f-4cfd-a3d1-fbe415d5ce54",
+    },
+    {
+      "id": "c41e0573-8875-4a4e-856e-1f6e420d39f2",
+      "questionId": "f70a4043-8eea-48ce-80cb-9dd68f0075c8",
+    },
+    {
+      "id": "01060db7-47b3-487c-8589-cd8125b32f30",
+      "questionId": "06575de9-99ef-407f-ab59-8046e2467450",
+    },
+    {
+      "id": "9009ab37-6230-4f76-bc4e-4c5389ae5d18",
+      "questionId": "6d8f2416-61eb-4d7c-9499-af265f0e2bbf",
+    },
+    {
+      "id": "f6d6446a-f3fc-402e-a033-fca2e422612e",
+      "questionId": "428ea415-923a-4fb6-be7d-510a569bcb3b",
+    },
+    {
+      "id": "d840187a-1be5-444a-8d4f-f7ff2cf01382",
+      "questionId": "b70fe21c-11f4-4122-98bf-8594a2412f68",
+    },
+    {
+      "id": "fe45ce78-87db-4f5f-84e5-4a95ccd3714f",
+      "questionId": "f0e6f719-8309-4215-af93-273ddb0a0a4b",
+    },
+    {
+      "id": "a4ad887d-e779-40a4-8dc4-da8cfe9ddb41",
+      "questionId": "edefe330-a9bc-4eda-94e9-9fd172313023",
+    },
+    {
+      "id": "23ada08f-c975-4caa-a22f-6c84e0f091ab",
+      "questionId": "acad4524-e5c5-418e-9049-f4cc51e3fbd9",
+    },
+    {
+      "id": "8a4100a0-5418-417c-a497-44b2e7c32aaf",
+      "questionId": "2d1da962-4d25-4cde-8a06-9d338b07fe3c",
+    },
+    {
+      "id": "9c010677-b76d-4f59-ac43-d781a6f4e74c",
+      "questionId": "cfca8708-73de-4f07-be3d-7ab69a4e3725",
+    },
+    {
+      "id": "6ab8bb6e-3e52-47f0-a947-f0b0c3860203",
+      "questionId": "e7c0b8ce-e03c-40ba-8c89-53bff74528e2",
+    },
+    {
+      "id": "ab952f3a-0e25-4ba3-9269-1981ff56d96a",
+      "questionId": "690c8cae-2262-42be-8451-e858a386a2a7",
+    },
+    {
+      "id": "0f71ce99-a90d-48ca-946d-c62708cf80f6",
+      "questionId": "87681174-9ddf-4cb4-b79d-dade47e59670",
+    },
+    {
+      "id": "d217eb00-074c-4ab2-86cd-1ecafcb97757",
+      "questionId": "d983d39d-c906-4e43-a213-e25317ca85ad",
+    },
+    {
+      "id": "56af6c05-db48-499c-b32d-174dcafe76a8",
+      "questionId": "7bd38a61-eae0-4790-818d-98bdda27f2fe",
+    },
+    {
+      "id": "5fad5fa4-366f-4cc4-8faf-0f41d8d6223c",
+      "questionId": "e44492b0-ba38-425a-9b26-f6187cfac406",
+    },
+    {
+      "id": "8c3bc0e0-8a87-4de6-a786-186752f42cf9",
+      "questionId": "44bcfec5-15f7-4e6b-93e6-c2d218a5d958",
+    },
+    {
+      "id": "4782ab64-8d89-4728-8869-9183fc7595bc",
+      "questionId": "c66f213d-d82d-4487-bd84-fcc16c42bc12",
+    },
+    {
+      "id": "7e089be2-446c-4b15-b47a-0d02300c757d",
+      "questionId": "83ec1df6-61b0-4f0f-b1a0-85868f36504a",
+    },
+    {
+      "id": "5652948d-7d8b-44a8-bb1e-f38ac1277fe6",
+      "questionId": "a3d0274f-e899-4cb9-8f51-dd8a70c3da11",
+    },
+    {
+      "id": "3a13ca7b-a014-4da2-8037-c76387872414",
+      "questionId": "f947f030-47fe-4fa2-8f8f-ac491e4870f9",
+    },
+    {
+      "id": "f73fb1ad-460f-4e00-8952-977e77809cfb",
+      "questionId": "a6537faa-4599-471a-952b-6a6353678eca",
+    },
+    {
+      "id": "87719a18-8617-4c62-83c1-f6f5426ae9ea",
+      "questionId": "230b27d3-deb0-4205-a6ed-e4ee00245157",
+    },
+    {
+      "id": "d01d38a3-70a2-43c6-b504-9b362ee50a9f",
+      "questionId": "3c26a434-840a-4879-9d26-ffe43a40cbb9",
+    },
+    {
+      "id": "f35d4445-a478-4fa6-97d3-60f17a6190e8",
+      "questionId": "6a48d3d3-0b58-4852-a500-9eb907a8bb19",
+    },
+    {
+      "id": "186d685c-6c3e-4447-b414-51f0bdbfe074",
+      "questionId": "17b109bc-907c-407a-8f72-d66076911a70",
+    },
+    {
+      "id": "8165efb7-2594-4108-a313-648c51f24974",
+      "questionId": "1d982e83-fe47-4a63-9cee-d981e4c4904d",
+    },
+    {
+      "id": "4b7ba131-4821-47e9-9f3d-512d6ca3eae2",
+      "questionId": "f298ba0b-62c1-4b53-9a75-7945e2f029f6",
+    },
+    {
+      "id": "43110d10-df5b-41ed-bde9-5ed222a9ef65",
+      "questionId": "a8441874-6a87-4499-ae41-c82e792136ba",
+    },
+    {
+      "id": "5ba2beda-b159-4672-bf66-50c9dbb4efea",
+      "questionId": "fdaa8909-b6be-46b8-a2e0-60cac2bf0eb8",
+    },
+    {
+      "id": "c0907d7f-180a-4592-b68f-ed84ab599764",
+      "questionId": "c3f99998-cb6c-4b3d-ad3e-2bcf2f257069",
+    },
+    {
+      "id": "9a522513-e75a-4d26-ab9b-7fbb0b954f53",
+      "questionId": "2a2fe409-b5b6-4bc8-9c21-8248d9cd020b",
+    },
+    {
+      "id": "50c54597-21b9-4e8a-b6bb-65a2957d5d6d",
+      "questionId": "ce3ae121-e61b-4c92-a9ea-02072a962772",
+    },
+    {
+      "id": "59f4ca8f-034c-4a0c-ae07-e4789177ba4a",
+      "questionId": "0d4204af-0ad5-4448-8d97-ad3b023fe9ed",
+    },
+    {
+      "id": "71f7b18a-536e-468b-9522-526fa1940f37",
+      "questionId": "38c3828e-444f-4770-9f4c-4910bb54cc0a",
+    },
+    {
+      "id": "29ece213-9e2e-4dc1-a78b-b52959e63ca1",
+      "questionId": "1c5b70f1-c7ef-4669-9cdc-97138ecba701",
+    },
+    {
+      "id": "cbb0a466-8561-47f4-a045-3da90c50ff3e",
+      "questionId": "8ea1c704-ecae-4555-b5ed-a8e9fc6e99e5",
+    },
+    {
+      "id": "cdc6ebaf-cc52-46a7-a029-4f15c7ba28b6",
+      "questionId": "4a530557-7254-4fbd-96b7-770071376510",
+    },
+    {
+      "id": "042d79cb-dd8d-49b4-8149-6f2bbc0decce",
+      "questionId": "c66df6bb-f651-4d90-9262-521d952b4d80",
+    },
+    {
+      "id": "39aa6731-c5df-4b4e-ab6a-2fb4a047f24f",
+      "questionId": "059f0be9-0812-4ae8-8ae9-5789b1a45227",
+    },
+    {
+      "id": "99bf073a-6207-456d-bc9f-4a23a37f03f3",
+      "questionId": "ad3b3737-f005-421a-a007-bd113aa559bb",
+    },
+    {
+      "id": "cb017d46-0391-4fd3-84af-5a6a65936098",
+      "questionId": "4a7a367e-3cfa-43a3-a851-94ba3116228e",
+    },
+    {
+      "id": "9b3314a4-6a72-48b9-b9a6-af26f6e1659d",
+      "questionId": "94282b4f-cb55-4199-ab72-c6ca765e601d",
+    },
+    {
+      "id": "04f341f3-de9a-46d1-9c5f-7f2d66f0dc6b",
+      "questionId": "209ebf99-ee8f-47cd-bf08-c98a252ea9bb",
+    },
+    {
+      "id": "6cab652c-5754-43f8-a552-8a137d76e50f",
+      "questionId": "f9e86b69-1eb2-4f55-b8d4-7fb7c69ebd45",
+    },
+    {
       "id": "df5c4ed7-7109-4c20-88dd-87e05833d16f",
       "questionId": "3868f16c-c4e5-4df1-9c2e-eeafe926473d",
     },
@@ -987,6 +1227,12 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "id": "3ad31ae2-3870-4d9d-8826-284bd8c34b12",
     },
     {
+      "id": "f91d2e2e-3fc8-45b5-ae64-e08a7d075e24",
+    },
+    {
+      "id": "5a95b965-7626-4c7d-98db-4c45bf72083a",
+    },
+    {
       "id": "ec8270ca-1f32-4928-a2c6-2f998f6061b6",
     },
     {
@@ -1045,6 +1291,9 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
     },
     {
       "id": "9c8e5d2a-4b7f-4c8d-9e0a-1b2c3d4e5f6a",
+    },
+    {
+      "id": "7496bad2-981e-4ac5-b464-788c4fc0d118",
     },
     {
       "id": "87a1da94-793c-4565-8706-8fd073a50cf6",
@@ -1158,6 +1407,9 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "id": "4a360125-e963-4c2b-88a8-d86aee59d8bc",
     },
     {
+      "id": "e82b0404-286d-42ee-89a9-e54776575d9f",
+    },
+    {
       "id": "b4de3329-f3af-4ae9-b67d-bf1c5d1a30fb",
     },
     {
@@ -1198,6 +1450,16 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "id": "c28b0006-13a2-422d-ae56-b75ddc686087",
       "postrequisiteId": "98c59241-27f0-4aec-9e33-84404d014b73",
       "prerequisiteId": "af0bd650-5f32-4dad-ba38-cea69f616692",
+    },
+    {
+      "id": "e08f5dfb-a229-4805-a343-aeefd3e449dd",
+      "postrequisiteId": "f91d2e2e-3fc8-45b5-ae64-e08a7d075e24",
+      "prerequisiteId": "3ad31ae2-3870-4d9d-8826-284bd8c34b12",
+    },
+    {
+      "id": "b4a907e5-c49a-4368-9c50-fd625540285f",
+      "postrequisiteId": "5a95b965-7626-4c7d-98db-4c45bf72083a",
+      "prerequisiteId": "f91d2e2e-3fc8-45b5-ae64-e08a7d075e24",
     },
     {
       "id": "bba994cb-72e3-465e-b4fa-47d2189870b1",
@@ -1248,6 +1510,11 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "id": "1744d33d-8c25-421f-9104-6fb50ea30ccb",
       "postrequisiteId": "9c8e5d2a-4b7f-4c8d-9e0a-1b2c3d4e5f6a",
       "prerequisiteId": "81BE3915-2C63-470E-85FE-55C1062DEFF3",
+    },
+    {
+      "id": "e110371c-44f6-4715-b394-fe9b21e18155",
+      "postrequisiteId": "7496bad2-981e-4ac5-b464-788c4fc0d118",
+      "prerequisiteId": "9c8e5d2a-4b7f-4c8d-9e0a-1b2c3d4e5f6a",
     },
     {
       "id": "fcfd331c-bd37-4a51-b638-866fa5df19fe",
@@ -1303,6 +1570,11 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "id": "a1b2c3d4-e5f6-4789-a012-bcdef3456789",
       "postrequisiteId": "bd8947e7-bd42-4ea0-976b-639ec22fe2ea",
       "prerequisiteId": "81BE3915-2C63-470E-85FE-55C1062DEFF3",
+    },
+    {
+      "id": "9959f18b-ffd8-4940-858b-da4aa984e5fb",
+      "postrequisiteId": "e82b0404-286d-42ee-89a9-e54776575d9f",
+      "prerequisiteId": "4a360125-e963-4c2b-88a8-d86aee59d8bc",
     },
     {
       "id": "4a400758-507b-4ff0-9799-026577878064",
@@ -2027,6 +2299,16 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "translationId": "93924e0d-75b4-4ce6-9685-272717eb813a",
     },
     {
+      "blockId": "f91d2e2e-3fc8-45b5-ae64-e08a7d075e24",
+      "id": "f91d2e2e-3fc8-45b5-ae64-e08a7d075e24",
+      "translationId": "6e8bdbda-dffc-43bf-ba78-28fc024ac8b9",
+    },
+    {
+      "blockId": "5a95b965-7626-4c7d-98db-4c45bf72083a",
+      "id": "5a95b965-7626-4c7d-98db-4c45bf72083a",
+      "translationId": "b665e731-2442-4bbe-8454-599af60e1454",
+    },
+    {
       "blockId": "ec8270ca-1f32-4928-a2c6-2f998f6061b6",
       "id": "ec8270ca-1f32-4928-a2c6-2f998f6061b6",
       "translationId": "c3f0f380-14e4-4a4f-acc8-2e6e8174d929",
@@ -2125,6 +2407,11 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "blockId": "9c8e5d2a-4b7f-4c8d-9e0a-1b2c3d4e5f6a",
       "id": "9c8e5d2a-4b7f-4c8d-9e0a-1b2c3d4e5f6a",
       "translationId": "b8a9c2d3-4e5f-4567-8901-2a3b4c5d6e7f",
+    },
+    {
+      "blockId": "7496bad2-981e-4ac5-b464-788c4fc0d118",
+      "id": "7496bad2-981e-4ac5-b464-788c4fc0d118",
+      "translationId": "4c1dfb25-25a7-4d2c-9d97-a6df46feb3f4",
     },
     {
       "blockId": "87a1da94-793c-4565-8706-8fd073a50cf6",
@@ -2310,6 +2597,11 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "blockId": "4a360125-e963-4c2b-88a8-d86aee59d8bc",
       "id": "4a360125-e963-4c2b-88a8-d86aee59d8bc",
       "translationId": "f0557643-39f1-41d8-b4bd-14d5242e7102",
+    },
+    {
+      "blockId": "e82b0404-286d-42ee-89a9-e54776575d9f",
+      "id": "e82b0404-286d-42ee-89a9-e54776575d9f",
+      "translationId": "b2bfed06-5f13-4c27-9611-b4cd1bbd258b",
     },
     {
       "blockId": "b4de3329-f3af-4ae9-b67d-bf1c5d1a30fb",
@@ -3102,6 +3394,156 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "answerId": "92ee7f0b-c860-4d44-bb49-bab1a0d8219a",
       "id": "b5440b1c-d752-4bdd-9a2c-a06d45c16360",
       "value": 4,
+    },
+    {
+      "answerId": "f29268fd-8d42-4d79-8a57-495558a888b6",
+      "id": "e6b9a892-9048-4421-a5c5-0121ccb2840c",
+      "value": -2,
+    },
+    {
+      "answerId": "b241bfc1-748f-4775-b4a9-fa10d2eccac2",
+      "id": "a905d6da-c995-44bd-98ad-b4c763612c37",
+      "value": 7,
+    },
+    {
+      "answerId": "63556833-7bac-4e95-871d-bf8e144f4884",
+      "id": "13d3d69e-99cd-4597-8f17-408a43e54b9e",
+      "value": 1,
+    },
+    {
+      "answerId": "e3e85d47-8d35-4521-b507-c81d5bb579e9",
+      "id": "d6f354ae-a80f-4914-a90a-81d18678c831",
+      "value": 10,
+    },
+    {
+      "answerId": "4f6ca6ae-c225-4f08-bc06-5ada7cf659b5",
+      "id": "b6b2d040-a25b-4648-a289-415f75323d34",
+      "value": 1,
+    },
+    {
+      "answerId": "e5142250-326f-4d55-b8e4-86dcdc45af64",
+      "id": "7630e911-4885-4981-805e-3a9efc325a5a",
+      "value": -14,
+    },
+    {
+      "answerId": "194dbc1b-0029-42b3-9423-1e48c4da3a67",
+      "id": "9ab2e8ec-5256-4784-8d75-70d1b73f5dec",
+      "value": -2,
+    },
+    {
+      "answerId": "011ab3ff-8455-417c-89e7-98b5253ea4c6",
+      "id": "b91aa194-f9f6-4245-91d8-0902704fac0f",
+      "value": -5,
+    },
+    {
+      "answerId": "1f0b8cd6-881b-4448-b5cb-880a85d88006",
+      "id": "58c1ce2a-17dc-4c42-ad9c-396027edcd15",
+      "value": 8,
+    },
+    {
+      "answerId": "2b17eb29-dca2-4d32-8459-b5df2b60a24f",
+      "id": "a701896a-2605-4458-a46b-cfd4067873f6",
+      "value": -32,
+    },
+    {
+      "answerId": "db579826-aa94-49ac-ade8-f6ec932b5cb6",
+      "id": "0f541498-9f7f-4349-a817-f7a79b246884",
+      "value": -21,
+    },
+    {
+      "answerId": "b257b4b2-1f59-4928-8672-42c8c71ca6d3",
+      "id": "0b9d4862-fa44-4f3d-ab77-159c4dfacc61",
+      "value": -29,
+    },
+    {
+      "answerId": "08fe5e6c-4385-4bea-8b5d-ef579b879823",
+      "id": "48ba0242-d0ba-43d8-91a8-cf63528878a6",
+      "value": 1,
+    },
+    {
+      "answerId": "0dfe6ced-c9d8-48a7-bd07-62b5ae1a05ba",
+      "id": "a9009ba2-0123-44d8-99fa-63b2b9aeffe7",
+      "value": -48,
+    },
+    {
+      "answerId": "450c2f52-703a-488e-b0a1-b162d1e765c6",
+      "id": "440d6993-091f-45c3-89f7-150119b79788",
+      "value": 0,
+    },
+    {
+      "answerId": "c41e0573-8875-4a4e-856e-1f6e420d39f2",
+      "id": "3d010e01-7bf0-4499-b42a-f9756241eb7a",
+      "value": 10,
+    },
+    {
+      "answerId": "01060db7-47b3-487c-8589-cd8125b32f30",
+      "id": "fe4f8853-bbc6-45e7-8ee6-2182a411c7d4",
+      "value": 16,
+    },
+    {
+      "answerId": "9009ab37-6230-4f76-bc4e-4c5389ae5d18",
+      "id": "885d4c4e-64ff-4c98-8607-ad648c612ede",
+      "value": 21,
+    },
+    {
+      "answerId": "f6d6446a-f3fc-402e-a033-fca2e422612e",
+      "id": "8410d7b8-b184-4c84-aa64-1abb9d10f24d",
+      "value": 2,
+    },
+    {
+      "answerId": "d840187a-1be5-444a-8d4f-f7ff2cf01382",
+      "id": "b5d746d0-8bbd-4ca2-97c2-249f466fc1ce",
+      "value": 50,
+    },
+    {
+      "answerId": "fe45ce78-87db-4f5f-84e5-4a95ccd3714f",
+      "id": "0a07733e-37cd-4595-87cf-bfda70b3ff80",
+      "value": 10,
+    },
+    {
+      "answerId": "a4ad887d-e779-40a4-8dc4-da8cfe9ddb41",
+      "id": "7520a2ab-b869-47c7-a780-e447b98589d0",
+      "value": -51,
+    },
+    {
+      "answerId": "23ada08f-c975-4caa-a22f-6c84e0f091ab",
+      "id": "a9f5eef4-2862-4094-b5ca-e9a152ed02ed",
+      "value": 29,
+    },
+    {
+      "answerId": "8a4100a0-5418-417c-a497-44b2e7c32aaf",
+      "id": "44db7595-099a-490a-a411-a51c2bb09aed",
+      "value": -7,
+    },
+    {
+      "answerId": "9c010677-b76d-4f59-ac43-d781a6f4e74c",
+      "id": "8226bed7-d907-40e7-be0d-8413b51d7a35",
+      "value": 72,
+    },
+    {
+      "answerId": "6ab8bb6e-3e52-47f0-a947-f0b0c3860203",
+      "id": "93485c0a-472d-4d98-89ba-7e9a93517f13",
+      "value": 93,
+    },
+    {
+      "answerId": "ab952f3a-0e25-4ba3-9269-1981ff56d96a",
+      "id": "2a354966-d47e-440a-9898-68d7618856b2",
+      "value": 0,
+    },
+    {
+      "answerId": "0f71ce99-a90d-48ca-946d-c62708cf80f6",
+      "id": "96042ca2-8396-4f48-a4b3-460b4d8a3fc6",
+      "value": 6,
+    },
+    {
+      "answerId": "d217eb00-074c-4ab2-86cd-1ecafcb97757",
+      "id": "57c6160e-d3f9-4099-af99-7f745cce66f1",
+      "value": -3,
+    },
+    {
+      "answerId": "56af6c05-db48-499c-b32d-174dcafe76a8",
+      "id": "b1579129-af23-4151-8a98-6ad102763cdf",
+      "value": -10,
     },
   ],
   "question": [
@@ -4173,6 +4615,366 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "validationStatus": "ai_generated",
     },
     {
+      "id": "52c4d70d-5b41-40eb-841a-d655bee0ded0",
+      "translationId": "52c4d70d-5b41-40eb-841a-d655bee0ded0",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "e52169d0-cba2-4889-b327-3a2f610df34f",
+      "translationId": "e52169d0-cba2-4889-b327-3a2f610df34f",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "4817954c-91ff-460d-a69b-a50507781d48",
+      "translationId": "4817954c-91ff-460d-a69b-a50507781d48",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "3ed9edf5-6783-4a6c-8421-5b6e39f4416e",
+      "translationId": "3ed9edf5-6783-4a6c-8421-5b6e39f4416e",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "9da9bb06-7c47-49e0-8e5f-2d705b8e0c65",
+      "translationId": "9da9bb06-7c47-49e0-8e5f-2d705b8e0c65",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "96d606d2-95d4-42bf-b6bd-40e20deea584",
+      "translationId": "96d606d2-95d4-42bf-b6bd-40e20deea584",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "055356ae-1862-4150-8b82-2f53f3abd864",
+      "translationId": "055356ae-1862-4150-8b82-2f53f3abd864",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "fb6d6ef9-dd8e-4e77-969d-bbe4b2c65a8a",
+      "translationId": "fb6d6ef9-dd8e-4e77-969d-bbe4b2c65a8a",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "8ddfb44e-b729-4d52-946b-ccef0fdc7639",
+      "translationId": "8ddfb44e-b729-4d52-946b-ccef0fdc7639",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "08eb3b54-0990-4767-a1bc-f06af3845a4b",
+      "translationId": "08eb3b54-0990-4767-a1bc-f06af3845a4b",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "abebb16a-625f-46bc-86f7-8d62b26a0068",
+      "translationId": "abebb16a-625f-46bc-86f7-8d62b26a0068",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "6418770c-9dc3-46fe-a975-c9cf96a1e6e1",
+      "translationId": "6418770c-9dc3-46fe-a975-c9cf96a1e6e1",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "0f2a875a-76ae-4d97-af58-6ad023ca5097",
+      "translationId": "0f2a875a-76ae-4d97-af58-6ad023ca5097",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "ce287b90-6484-4619-b3e0-96c3a9a246c0",
+      "translationId": "ce287b90-6484-4619-b3e0-96c3a9a246c0",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "2343d8a5-264f-4cfd-a3d1-fbe415d5ce54",
+      "translationId": "2343d8a5-264f-4cfd-a3d1-fbe415d5ce54",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "f70a4043-8eea-48ce-80cb-9dd68f0075c8",
+      "translationId": "f70a4043-8eea-48ce-80cb-9dd68f0075c8",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "06575de9-99ef-407f-ab59-8046e2467450",
+      "translationId": "06575de9-99ef-407f-ab59-8046e2467450",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "6d8f2416-61eb-4d7c-9499-af265f0e2bbf",
+      "translationId": "6d8f2416-61eb-4d7c-9499-af265f0e2bbf",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "428ea415-923a-4fb6-be7d-510a569bcb3b",
+      "translationId": "428ea415-923a-4fb6-be7d-510a569bcb3b",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "b70fe21c-11f4-4122-98bf-8594a2412f68",
+      "translationId": "b70fe21c-11f4-4122-98bf-8594a2412f68",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "f0e6f719-8309-4215-af93-273ddb0a0a4b",
+      "translationId": "f0e6f719-8309-4215-af93-273ddb0a0a4b",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "edefe330-a9bc-4eda-94e9-9fd172313023",
+      "translationId": "edefe330-a9bc-4eda-94e9-9fd172313023",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "acad4524-e5c5-418e-9049-f4cc51e3fbd9",
+      "translationId": "acad4524-e5c5-418e-9049-f4cc51e3fbd9",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "2d1da962-4d25-4cde-8a06-9d338b07fe3c",
+      "translationId": "2d1da962-4d25-4cde-8a06-9d338b07fe3c",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "cfca8708-73de-4f07-be3d-7ab69a4e3725",
+      "translationId": "cfca8708-73de-4f07-be3d-7ab69a4e3725",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "e7c0b8ce-e03c-40ba-8c89-53bff74528e2",
+      "translationId": "e7c0b8ce-e03c-40ba-8c89-53bff74528e2",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "690c8cae-2262-42be-8451-e858a386a2a7",
+      "translationId": "690c8cae-2262-42be-8451-e858a386a2a7",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "87681174-9ddf-4cb4-b79d-dade47e59670",
+      "translationId": "87681174-9ddf-4cb4-b79d-dade47e59670",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "d983d39d-c906-4e43-a213-e25317ca85ad",
+      "translationId": "d983d39d-c906-4e43-a213-e25317ca85ad",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "7bd38a61-eae0-4790-818d-98bdda27f2fe",
+      "translationId": "7bd38a61-eae0-4790-818d-98bdda27f2fe",
+      "type": "value",
+      "validationStatus": "approved",
+    },
+    {
+      "id": "e44492b0-ba38-425a-9b26-f6187cfac406",
+      "translationId": "307b002b-ed58-4612-bd5e-9d189ff11db0",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "44bcfec5-15f7-4e6b-93e6-c2d218a5d958",
+      "translationId": "b3a07885-f515-4a33-ac10-5c92695d0172",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "c66f213d-d82d-4487-bd84-fcc16c42bc12",
+      "translationId": "b84aaec3-5374-460e-abc7-dd26801acc97",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "83ec1df6-61b0-4f0f-b1a0-85868f36504a",
+      "translationId": "9ebf3fd4-4f97-42fb-aef5-a5c133c95c09",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "a3d0274f-e899-4cb9-8f51-dd8a70c3da11",
+      "translationId": "4e5741bc-dbe6-4590-913f-9926f6adcfe7",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "f947f030-47fe-4fa2-8f8f-ac491e4870f9",
+      "translationId": "daaefdba-936f-43b0-8fca-e5a0000f7ef2",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "a6537faa-4599-471a-952b-6a6353678eca",
+      "translationId": "adb534c9-ed46-4cac-b3a2-3bb5bac43fda",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "230b27d3-deb0-4205-a6ed-e4ee00245157",
+      "translationId": "1e25b879-86db-44e8-a04a-00d9dabe0a43",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "3c26a434-840a-4879-9d26-ffe43a40cbb9",
+      "translationId": "c517c697-0854-4307-931b-0d4d24e3f568",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "6a48d3d3-0b58-4852-a500-9eb907a8bb19",
+      "translationId": "c4547ab8-2327-48e1-86ca-ece2f0df0e8d",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "17b109bc-907c-407a-8f72-d66076911a70",
+      "translationId": "8d3a08b5-5065-4cb7-8630-cc2f6cc13b53",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "1d982e83-fe47-4a63-9cee-d981e4c4904d",
+      "translationId": "9e6be0ca-8822-433b-9434-25faebe6ff2a",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "f298ba0b-62c1-4b53-9a75-7945e2f029f6",
+      "translationId": "7bcb583d-015a-48bd-974f-d7ad92258dca",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "a8441874-6a87-4499-ae41-c82e792136ba",
+      "translationId": "742b4b5c-01c1-4429-9956-2cb32f0171f6",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "fdaa8909-b6be-46b8-a2e0-60cac2bf0eb8",
+      "translationId": "55331a85-439b-4bd0-ac2e-81cb5bc530f2",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "c3f99998-cb6c-4b3d-ad3e-2bcf2f257069",
+      "translationId": "8bae3b74-c8c6-45ae-8c81-1165321012e0",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "2a2fe409-b5b6-4bc8-9c21-8248d9cd020b",
+      "translationId": "b3558a47-7c4b-42a7-a82e-872531ede471",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "ce3ae121-e61b-4c92-a9ea-02072a962772",
+      "translationId": "30e153ce-be8a-4999-83db-08491ca78a16",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "0d4204af-0ad5-4448-8d97-ad3b023fe9ed",
+      "translationId": "f9aa190e-6d9e-4c57-aa90-f40c605d7863",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "38c3828e-444f-4770-9f4c-4910bb54cc0a",
+      "translationId": "98d14525-2829-493d-ba8b-7a3c3981deb9",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "1c5b70f1-c7ef-4669-9cdc-97138ecba701",
+      "translationId": "53ee56a0-ce58-498e-9eab-5d4b5979655b",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "8ea1c704-ecae-4555-b5ed-a8e9fc6e99e5",
+      "translationId": "4629eb56-9988-4784-9527-f01cc8b2b0a8",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "4a530557-7254-4fbd-96b7-770071376510",
+      "translationId": "c9848308-6852-4a3c-ab16-649fae324e55",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "c66df6bb-f651-4d90-9262-521d952b4d80",
+      "translationId": "fdeed27d-2ead-4743-b772-545a7585c2ab",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "059f0be9-0812-4ae8-8ae9-5789b1a45227",
+      "translationId": "af2d2a04-bf10-4cad-bbd1-8383ff2bd981",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "ad3b3737-f005-421a-a007-bd113aa559bb",
+      "translationId": "bb6e2d5d-ed1e-46b5-a016-d1a1b21053eb",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "4a7a367e-3cfa-43a3-a851-94ba3116228e",
+      "translationId": "8a8a4611-353d-4d9f-a19c-674dd54c68b8",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "94282b4f-cb55-4199-ab72-c6ca765e601d",
+      "translationId": "f8318255-f2f3-4c00-b628-1ef1371a2376",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "209ebf99-ee8f-47cd-bf08-c98a252ea9bb",
+      "translationId": "d8014943-6a36-4908-9aca-2923cf28452e",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
+      "id": "f9e86b69-1eb2-4f55-b8d4-7fb7c69ebd45",
+      "translationId": "a98199ac-0f21-4702-bfd4-95fc2667313a",
+      "type": "selection",
+      "validationStatus": "ai_generated",
+    },
+    {
       "id": "3868f16c-c4e5-4df1-9c2e-eeafe926473d",
       "translationId": "cb8ad153-c31b-4e22-91f6-c5e9e6f4637a",
       "type": "selection",
@@ -4231,6 +5033,18 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "value": "hard",
     },
     {
+      "blockRelationshipId": "e08f5dfb-a229-4805-a343-aeefd3e449dd",
+      "id": "f7445a44-2587-4ecd-b96c-0fa5382ca2a8",
+      "key": "TYPE",
+      "value": "hard",
+    },
+    {
+      "blockRelationshipId": "b4a907e5-c49a-4368-9c50-fd625540285f",
+      "id": "68c57ee8-118a-4008-92d7-119c35cf1a87",
+      "key": "TYPE",
+      "value": "hard",
+    },
+    {
       "blockRelationshipId": "7d8e9f01-1234-4345-a789-abcdef456012",
       "id": "7af77c38-a123-420c-a7f1-b685b54d64bd",
       "key": "TYPE",
@@ -4239,6 +5053,12 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
     {
       "blockRelationshipId": "8e9f0123-2345-4456-a89a-bcdef0567123",
       "id": "9aa0cc26-2d07-4ec7-b3b7-a10440362909",
+      "key": "TYPE",
+      "value": "hard",
+    },
+    {
+      "blockRelationshipId": "e110371c-44f6-4715-b394-fe9b21e18155",
+      "id": "05d2eb85-aa70-48c8-8e6d-4657417a7a5b",
       "key": "TYPE",
       "value": "hard",
     },
@@ -4275,6 +5095,12 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
     {
       "blockRelationshipId": "a1b2c3d4-e5f6-4789-a012-bcdef3456789",
       "id": "f11617c8-b281-4865-870d-a22b782d32a0",
+      "key": "TYPE",
+      "value": "hard",
+    },
+    {
+      "blockRelationshipId": "9959f18b-ffd8-4940-858b-da4aa984e5fb",
+      "id": "efe8c558-a765-474f-a471-ed1beda8bbfe",
       "key": "TYPE",
       "value": "hard",
     },
@@ -4993,6 +5819,366 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "id": "47377013-0153-460c-8ef4-9ecf306495e4",
       "isCorrect": false,
       "translationId": "c90dfde3-0732-42af-a85f-7843ded1b8a2",
+    },
+    {
+      "answerId": "5fad5fa4-366f-4cc4-8faf-0f41d8d6223c",
+      "id": "24dc16f4-a328-4305-a786-9f73171eed8d",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "5fad5fa4-366f-4cc4-8faf-0f41d8d6223c",
+      "id": "a42f894e-9fe5-4c03-a419-41a7d959405e",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "8c3bc0e0-8a87-4de6-a786-186752f42cf9",
+      "id": "c811f253-22a5-49cf-a306-6a7187e1268d",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "8c3bc0e0-8a87-4de6-a786-186752f42cf9",
+      "id": "57303f04-1655-4a3e-9273-0d4cc31b2d7a",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "4782ab64-8d89-4728-8869-9183fc7595bc",
+      "id": "42c56834-ab7d-4073-9e57-8c64c73b0f66",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "4782ab64-8d89-4728-8869-9183fc7595bc",
+      "id": "e6d22fcd-467f-4f41-8cad-8b187a59833d",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "7e089be2-446c-4b15-b47a-0d02300c757d",
+      "id": "e6010ee7-aa76-4b8d-a2ee-5876bd24f4de",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "7e089be2-446c-4b15-b47a-0d02300c757d",
+      "id": "89e809d3-0ea1-44ff-bf80-52073f34a4ea",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "5652948d-7d8b-44a8-bb1e-f38ac1277fe6",
+      "id": "a8bb93d0-b1e5-4202-96db-c0c25279a755",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "5652948d-7d8b-44a8-bb1e-f38ac1277fe6",
+      "id": "10772a06-459b-4542-b8b1-01a4b3041a62",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "3a13ca7b-a014-4da2-8037-c76387872414",
+      "id": "71113790-1d76-4453-9fce-46033d3d4584",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "3a13ca7b-a014-4da2-8037-c76387872414",
+      "id": "9b98199a-84f5-4b90-882f-ed5a0b811868",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "f73fb1ad-460f-4e00-8952-977e77809cfb",
+      "id": "74880440-3546-43f7-8c59-93ddfd394e4a",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "f73fb1ad-460f-4e00-8952-977e77809cfb",
+      "id": "71774e2a-4d52-4f57-9fe7-7bbf6d7d528c",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "87719a18-8617-4c62-83c1-f6f5426ae9ea",
+      "id": "861aa05c-8a31-4999-9741-49abbfe518dc",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "87719a18-8617-4c62-83c1-f6f5426ae9ea",
+      "id": "fae7cdd1-68c2-4c11-9fcb-71cb321cb6a1",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "d01d38a3-70a2-43c6-b504-9b362ee50a9f",
+      "id": "b370c78d-4d5f-4e66-8abc-4f70256a10d7",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "d01d38a3-70a2-43c6-b504-9b362ee50a9f",
+      "id": "0004fa8d-c559-40b2-a0dc-dfce6e10951e",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "f35d4445-a478-4fa6-97d3-60f17a6190e8",
+      "id": "9a6be0f4-3c17-4730-8701-20740e1f9246",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "f35d4445-a478-4fa6-97d3-60f17a6190e8",
+      "id": "f5ffc3b2-ad40-45c0-b9a2-2659d17558fb",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "186d685c-6c3e-4447-b414-51f0bdbfe074",
+      "id": "6ffc1d31-f56c-4306-83ec-575a0c81561a",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "186d685c-6c3e-4447-b414-51f0bdbfe074",
+      "id": "cf2b20d6-8dfa-4671-8944-35d1cf4a46f1",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "8165efb7-2594-4108-a313-648c51f24974",
+      "id": "72054dce-01e8-4734-b93a-305fa5f133e6",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "8165efb7-2594-4108-a313-648c51f24974",
+      "id": "679b7464-83db-4ebd-a1c2-2a9a2e3d9d91",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "4b7ba131-4821-47e9-9f3d-512d6ca3eae2",
+      "id": "545c796b-4adf-4b2c-82e7-c2649d3e71fd",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "4b7ba131-4821-47e9-9f3d-512d6ca3eae2",
+      "id": "0860ccbb-8185-4584-a436-4d91d829fd1c",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "43110d10-df5b-41ed-bde9-5ed222a9ef65",
+      "id": "e303821c-ae24-4691-8cb9-b214a5e6a9bd",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "43110d10-df5b-41ed-bde9-5ed222a9ef65",
+      "id": "7493a3b8-e2f1-44d1-8e3c-005f52e1186e",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "5ba2beda-b159-4672-bf66-50c9dbb4efea",
+      "id": "9748f334-6bec-406b-bd5b-c65ac78eaa32",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "5ba2beda-b159-4672-bf66-50c9dbb4efea",
+      "id": "1247e41b-359d-4310-b222-09cd08bf1753",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "c0907d7f-180a-4592-b68f-ed84ab599764",
+      "id": "ad93ee2e-3e0a-4792-9d80-8c53ad3d8a42",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "c0907d7f-180a-4592-b68f-ed84ab599764",
+      "id": "24fb651d-dd05-4fdd-ae8a-9e2eeb37ba22",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "9a522513-e75a-4d26-ab9b-7fbb0b954f53",
+      "id": "81d8456f-416e-4e8b-a679-e5f6ac581e09",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "9a522513-e75a-4d26-ab9b-7fbb0b954f53",
+      "id": "aa39cdb8-a09d-4fdb-9c07-c0bebf8110c2",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "50c54597-21b9-4e8a-b6bb-65a2957d5d6d",
+      "id": "31096318-9abf-4793-9b59-dc1ad562dc66",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "50c54597-21b9-4e8a-b6bb-65a2957d5d6d",
+      "id": "161c7349-896a-4481-9771-2334ee247227",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "59f4ca8f-034c-4a0c-ae07-e4789177ba4a",
+      "id": "a87999c9-7cf6-48a1-b53e-040a19c373ab",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "59f4ca8f-034c-4a0c-ae07-e4789177ba4a",
+      "id": "95ff00d1-1719-43eb-bc4a-4c467316b659",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "71f7b18a-536e-468b-9522-526fa1940f37",
+      "id": "f8d95ff4-7ab2-48d2-867d-8090ae357173",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "71f7b18a-536e-468b-9522-526fa1940f37",
+      "id": "ad0a06ed-81d1-47bd-bea9-bd7429602f0d",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "29ece213-9e2e-4dc1-a78b-b52959e63ca1",
+      "id": "9bec624b-6451-4256-8792-cff58f73bf09",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "29ece213-9e2e-4dc1-a78b-b52959e63ca1",
+      "id": "456bfa13-2fb4-4cd8-9b1e-2b961231b297",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "cbb0a466-8561-47f4-a045-3da90c50ff3e",
+      "id": "dc6c4de3-7fd3-4a61-bf11-3d27ad498a9c",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "cbb0a466-8561-47f4-a045-3da90c50ff3e",
+      "id": "5eeebe56-0a33-4f87-9f69-7a02ef31370a",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "cdc6ebaf-cc52-46a7-a029-4f15c7ba28b6",
+      "id": "e14e5f47-1629-4f25-969b-959379195adf",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "cdc6ebaf-cc52-46a7-a029-4f15c7ba28b6",
+      "id": "34c203ca-c140-4b34-9ecc-4b125aba9999",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "042d79cb-dd8d-49b4-8149-6f2bbc0decce",
+      "id": "33de3f3e-6bac-4ec7-aeec-2fdedf294c2b",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "042d79cb-dd8d-49b4-8149-6f2bbc0decce",
+      "id": "6e6aee5d-dec7-4b81-838c-ac63991c7c73",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "39aa6731-c5df-4b4e-ab6a-2fb4a047f24f",
+      "id": "3920f0a9-1fd3-4629-8759-7df269d9cb44",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "39aa6731-c5df-4b4e-ab6a-2fb4a047f24f",
+      "id": "bc57fc1f-52fa-43e5-aa96-5de80301cf60",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "99bf073a-6207-456d-bc9f-4a23a37f03f3",
+      "id": "93d9a850-ac81-4bfd-8e18-361a64fa1bb3",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "99bf073a-6207-456d-bc9f-4a23a37f03f3",
+      "id": "7f8245be-052d-4c7e-85be-bd0d5c4698ae",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "cb017d46-0391-4fd3-84af-5a6a65936098",
+      "id": "472d8f7b-d7b3-4bf9-a8f0-6bc8d23ea702",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "cb017d46-0391-4fd3-84af-5a6a65936098",
+      "id": "e8642c90-4928-460d-9c03-12c5f1bc633b",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "9b3314a4-6a72-48b9-b9a6-af26f6e1659d",
+      "id": "4a77e6cb-8a6c-4013-be1d-727db847daca",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "9b3314a4-6a72-48b9-b9a6-af26f6e1659d",
+      "id": "6fb0e471-3856-4a43-98a0-bba7b874a61e",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "04f341f3-de9a-46d1-9c5f-7f2d66f0dc6b",
+      "id": "ac1dfdb9-80ea-42ae-891b-abfea2de6137",
+      "isCorrect": true,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "04f341f3-de9a-46d1-9c5f-7f2d66f0dc6b",
+      "id": "e819dc5b-a820-4b86-8f41-a3787bbfac84",
+      "isCorrect": false,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
+    },
+    {
+      "answerId": "6cab652c-5754-43f8-a552-8a137d76e50f",
+      "id": "a56c3d51-d506-4d2e-a100-7c3b1cdad86d",
+      "isCorrect": false,
+      "translationId": "c1d6bbad-b174-4f06-8dbd-89aaac420be5",
+    },
+    {
+      "answerId": "6cab652c-5754-43f8-a552-8a137d76e50f",
+      "id": "79e0e7b5-88d4-4720-841b-23b20c08b9b8",
+      "isCorrect": true,
+      "translationId": "5ad96b46-8670-4368-858b-453472383bd2",
     },
     {
       "answerId": "df5c4ed7-7109-4c20-88dd-87e05833d16f",
@@ -7512,6 +8698,326 @@ In the Faculty of Arts, you're not just learning about the world — you're lear
       "en_text": "Level-order traversal",
       "he_text": "מעבר level-order",
       "id": "aebfcadb-fa7b-4cfd-aebf-cadbecfdaebf",
+    },
+    {
+      "en_text": "Matrix Algebra",
+      "he_text": "אלגברת מטריצות",
+      "id": "b665e731-2442-4bbe-8454-599af60e1454",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[1,2],[3,4]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[1,2],[3,4]]?",
+      "id": "52c4d70d-5b41-40eb-841a-d655bee0ded0",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[2,3],[1,5]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[2,3],[1,5]]?",
+      "id": "e52169d0-cba2-4889-b327-3a2f610df34f",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[0,1],[-1,3]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[0,1],[-1,3]]?",
+      "id": "4817954c-91ff-460d-a69b-a50507781d48",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[4,7],[2,6]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[4,7],[2,6]]?",
+      "id": "3ed9edf5-6783-4a6c-8421-5b6e39f4416e",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[5,2],[7,3]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[5,2],[7,3]]?",
+      "id": "9da9bb06-7c47-49e0-8e5f-2d705b8e0c65",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[3,8],[4,6]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[3,8],[4,6]]?",
+      "id": "96d606d2-95d4-42bf-b6bd-40e20deea584",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[2,0],[5,-1]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[2,0],[5,-1]]?",
+      "id": "055356ae-1862-4150-8b82-2f53f3abd864",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[-1,4],[2,-3]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[-1,4],[2,-3]]?",
+      "id": "fb6d6ef9-dd8e-4e77-969d-bbe4b2c65a8a",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[6,1],[4,2]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[6,1],[4,2]]?",
+      "id": "8ddfb44e-b729-4d52-946b-ccef0fdc7639",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[3,5],[7,1]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[3,5],[7,1]]?",
+      "id": "08eb3b54-0990-4767-a1bc-f06af3845a4b",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[1,0,2],[-1,3,1],[3,1,0]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[1,0,2],[-1,3,1],[3,1,0]]?",
+      "id": "abebb16a-625f-46bc-86f7-8d62b26a0068",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[2,-1,0],[1,3,4],[5,2,1]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[2,-1,0],[1,3,4],[5,2,1]]?",
+      "id": "6418770c-9dc3-46fe-a975-c9cf96a1e6e1",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[1,2,3],[0,1,4],[5,6,0]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[1,2,3],[0,1,4],[5,6,0]]?",
+      "id": "0f2a875a-76ae-4d97-af58-6ad023ca5097",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[2,1,3],[0,4,5],[6,7,8]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[2,1,3],[0,4,5],[6,7,8]]?",
+      "id": "ce287b90-6484-4619-b3e0-96c3a9a246c0",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[1,4,7],[2,5,8],[3,6,9]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[1,4,7],[2,5,8],[3,6,9]]?",
+      "id": "2343d8a5-264f-4cfd-a3d1-fbe415d5ce54",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[3,0,2],[2,0,-2],[0,1,1]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[3,0,2],[2,0,-2],[0,1,1]]?",
+      "id": "f70a4043-8eea-48ce-80cb-9dd68f0075c8",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[1,2,0],[0,3,4],[5,6,0]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[1,2,0],[0,3,4],[5,6,0]]?",
+      "id": "06575de9-99ef-407f-ab59-8046e2467450",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[2,5,3],[1,-2,0],[3,4,1]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[2,5,3],[1,-2,0],[3,4,1]]?",
+      "id": "6d8f2416-61eb-4d7c-9499-af265f0e2bbf",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[1,2,1],[0,1,0],[2,3,4]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[1,2,1],[0,1,0],[2,3,4]]?",
+      "id": "428ea415-923a-4fb6-be7d-510a569bcb3b",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[4,1,2],[0,3,1],[2,0,5]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[4,1,2],[0,3,1],[2,0,5]]?",
+      "id": "b70fe21c-11f4-4122-98bf-8594a2412f68",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[2,-1,3],[0,4,-2],[1,5,0]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[2,-1,3],[0,4,-2],[1,5,0]]?",
+      "id": "f0e6f719-8309-4215-af93-273ddb0a0a4b",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[3,2,1],[1,0,4],[2,5,6]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[3,2,1],[1,0,4],[2,5,6]]?",
+      "id": "edefe330-a9bc-4eda-94e9-9fd172313023",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[0,2,1],[3,1,4],[5,-2,0]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[0,2,1],[3,1,4],[5,-2,0]]?",
+      "id": "acad4524-e5c5-418e-9049-f4cc51e3fbd9",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[1,4,2],[2,1,3],[3,5,6]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[1,4,2],[2,1,3],[3,5,6]]?",
+      "id": "2d1da962-4d25-4cde-8a06-9d338b07fe3c",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[2,3,1],[4,1,5],[6,2,0]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[2,3,1],[4,1,5],[6,2,0]]?",
+      "id": "cfca8708-73de-4f07-be3d-7ab69a4e3725",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[4,2,-1],[3,5,2],[1,0,6]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[4,2,-1],[3,5,2],[1,0,6]]?",
+      "id": "e7c0b8ce-e03c-40ba-8c89-53bff74528e2",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[1,3,5],[2,4,6],[7,8,9]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[1,3,5],[2,4,6],[7,8,9]]?",
+      "id": "690c8cae-2262-42be-8451-e858a386a2a7",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[2,4,6],[1,-1,0],[3,5,7]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[2,4,6],[1,-1,0],[3,5,7]]?",
+      "id": "87681174-9ddf-4cb4-b79d-dade47e59670",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[3,1,2],[4,2,3],[5,0,1]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[3,1,2],[4,2,3],[5,0,1]]?",
+      "id": "d983d39d-c906-4e43-a213-e25317ca85ad",
+    },
+    {
+      "en_text": "What is the determinant of the matrix [[5,2,1],[0,3,4],[2,1,0]]?",
+      "he_text": "מהו הדטרמיננטה של המטריצה [[5,2,1],[0,3,4],[2,1,0]]?",
+      "id": "7bd38a61-eae0-4790-818d-98bdda27f2fe",
+    },
+    {
+      "en_text": "Linear Equations",
+      "he_text": "משוואות לינאריות",
+      "id": "6e8bdbda-dffc-43bf-ba78-28fc024ac8b9",
+    },
+    {
+      "en_text": "Probability Basics",
+      "he_text": "יסודות ההסתברות",
+      "id": "4c1dfb25-25a7-4d2c-9d97-a6df46feb3f4",
+    },
+    {
+      "en_text": "Sequences and Series",
+      "he_text": "סדרות וטורים",
+      "id": "b2bfed06-5f13-4c27-9611-b4cd1bbd258b",
+    },
+    {
+      "en_text": "Is x=2 a solution to 3x-6=0",
+      "he_text": "האם x=2 הוא פתרון למשוואה 3x-6=0",
+      "id": "307b002b-ed58-4612-bd5e-9d189ff11db0",
+    },
+    {
+      "en_text": "Is x=4 a solution to 2x+1=9",
+      "he_text": "האם x=4 הוא פתרון למשוואה 2x+1=9",
+      "id": "b3a07885-f515-4a33-ac10-5c92695d0172",
+    },
+    {
+      "en_text": "Is x=1 a solution to 5x+2=12",
+      "he_text": "האם x=1 הוא פתרון למשוואה 5x+2=12",
+      "id": "b84aaec3-5374-460e-abc7-dd26801acc97",
+    },
+    {
+      "en_text": "Is x=3 a solution to x/2-3=1",
+      "he_text": "האם x=3 הוא פתרון למשוואה x/2-3=1",
+      "id": "9ebf3fd4-4f97-42fb-aef5-a5c133c95c09",
+    },
+    {
+      "en_text": "Is x=3 and y=2 a solution to system x+y=5 and x-y=1",
+      "he_text": "האם x=3 ו y=2 הם פתרון למערכת x+y=5 ו x-y=1",
+      "id": "4e5741bc-dbe6-4590-913f-9926f6adcfe7",
+    },
+    {
+      "en_text": "Is x=1 and y=1 a solution to system 2x+3y=6 and x-y=0",
+      "he_text": "האם x=1 ו y=1 הם פתרון למערכת 2x+3y=6 ו x-y=0",
+      "id": "daaefdba-936f-43b0-8fca-e5a0000f7ef2",
+    },
+    {
+      "en_text": "Is x=1 a solution to 7x-4=3",
+      "he_text": "האם x=1 הוא פתרון למשוואה 7x-4=3",
+      "id": "adb534c9-ed46-4cac-b3a2-3bb5bac43fda",
+    },
+    {
+      "en_text": "Is x=0 a solution to 4x+5=5",
+      "he_text": "האם x=0 הוא פתרון למשוואה 4x+5=5",
+      "id": "1e25b879-86db-44e8-a04a-00d9dabe0a43",
+    },
+    {
+      "en_text": "Is x=1 and y=0 a solution to system x+y=1 and 2x+2y=2",
+      "he_text": "האם x=1 ו y=0 הם פתרון למערכת x+y=1 ו 2x+2y=2",
+      "id": "c517c697-0854-4307-931b-0d4d24e3f568",
+    },
+    {
+      "en_text": "Is x=1/3 a solution to 6x-2=1",
+      "he_text": "האם x=1/3 הוא פתרון למשוואה 6x-2=1",
+      "id": "c4547ab8-2327-48e1-86ca-ece2f0df0e8d",
+    },
+    {
+      "en_text": "In a fair coin toss is probability of heads 0.5",
+      "he_text": "בהטלת מטבע הוגנת האם ההסתברות לצד עץ היא 0.5",
+      "id": "8d3a08b5-5065-4cb7-8630-cc2f6cc13b53",
+    },
+    {
+      "en_text": "Is probability of rolling a 7 on a six sided die 1/6",
+      "he_text": "האם ההסתברות לגלגל 7 בקובייה בעלת שש פאות היא 1/6",
+      "id": "9e6be0ca-8822-433b-9434-25faebe6ff2a",
+    },
+    {
+      "en_text": "For two independent events each with probability 0.5 is probability that both occur 0.25",
+      "he_text": "עבור שני אירועים בלתי תלויים שכל אחד בעל הסתברות 0.5 האם ההסתברות ששניהם יקרו היא 0.25",
+      "id": "7bcb583d-015a-48bd-974f-d7ad92258dca",
+    },
+    {
+      "en_text": "Is probability of drawing an ace from a standard deck 1/13",
+      "he_text": "האם ההסתברות לשלוף אס מחפיסת קלפים רגילה היא 1/13",
+      "id": "742b4b5c-01c1-4429-9956-2cb32f0171f6",
+    },
+    {
+      "en_text": "Are events with probabilities 0.3 and 0.8 always mutually exclusive",
+      "he_text": "האם אירועים בעלי הסתברויות 0.3 ו 0.8 תמיד זרים",
+      "id": "55331a85-439b-4bd0-ac2e-81cb5bc530f2",
+    },
+    {
+      "en_text": "Is expected value of a fair six sided die 3.5",
+      "he_text": "האם התוחלת של קובייה הוגנת בעלת שש פאות היא 3.5",
+      "id": "8bae3b74-c8c6-45ae-8c81-1165321012e0",
+    },
+    {
+      "en_text": "Is variance of a fair six sided die 35/12",
+      "he_text": "האם השונות של קובייה הוגנת בעלת שש פאות היא 35/12",
+      "id": "b3558a47-7c4b-42a7-a82e-872531ede471",
+    },
+    {
+      "en_text": "Is probability of at least one tail in two fair coin tosses 0.75",
+      "he_text": "האם ההסתברות לפחות פלי אחד בשתי הטלות מטבע הוגנות היא 0.75",
+      "id": "30e153ce-be8a-4999-83db-08491ca78a16",
+    },
+    {
+      "en_text": "Is probability that a randomly chosen day of the week is weekend 2/7",
+      "he_text": "האם ההסתברות שיום בשבוע הנבחר באקראי הוא סוף שבוע היא 2/7",
+      "id": "f9aa190e-6d9e-4c57-aa90-f40c605d7863",
+    },
+    {
+      "en_text": "If event A has probability 0.4 is probability of its complement 0.7",
+      "he_text": "אם לאירוע A הסתברות 0.4 האם להשלמתו הסתברות 0.7",
+      "id": "98d14525-2829-493d-ba8b-7a3c3981deb9",
+    },
+    {
+      "en_text": "Does geometric series sum from n=0 of (1/2)^n converge to 2",
+      "he_text": "האם הטור הגאומטרי Σ(1/2)^n מ n=0 מתכנס ל 2",
+      "id": "53ee56a0-ce58-498e-9eab-5d4b5979655b",
+    },
+    {
+      "en_text": "Is the series Σ 1/n convergent",
+      "he_text": "האם הטור Σ 1/n מתכנס",
+      "id": "4629eb56-9988-4784-9527-f01cc8b2b0a8",
+    },
+    {
+      "en_text": "Does the sequence a_n=1/n converge to 0",
+      "he_text": "האם הסדרה a_n=1/n מתכנסת ל 0",
+      "id": "c9848308-6852-4a3c-ab16-649fae324e55",
+    },
+    {
+      "en_text": "Is the series Σ(-1)^n convergent",
+      "he_text": "האם הטור Σ(-1)^n מתכנס",
+      "id": "fdeed27d-2ead-4743-b772-545a7585c2ab",
+    },
+    {
+      "en_text": "Is the sequence a_n=n^2 bounded",
+      "he_text": "האם הסדרה a_n=n^2 חסומה",
+      "id": "af2d2a04-bf10-4cad-bbd1-8383ff2bd981",
+    },
+    {
+      "en_text": "Does the series Σ1/n^2 converge",
+      "he_text": "האם הטור Σ1/n^2 מתכנס",
+      "id": "bb6e2d5d-ed1e-46b5-a016-d1a1b21053eb",
+    },
+    {
+      "en_text": "Is limit of sequence (1+1/n)^n equal to e",
+      "he_text": "האם הגבול של הסדרה (1+1/n)^n שווה ל e",
+      "id": "8a8a4611-353d-4d9f-a19c-674dd54c68b8",
+    },
+    {
+      "en_text": "Does the series Σ(-1)^n/n converge",
+      "he_text": "האם הטור Σ(-1)^n/n מתכנס",
+      "id": "f8318255-f2f3-4c00-b628-1ef1371a2376",
+    },
+    {
+      "en_text": "Is the sequence a_n=(-1)^n bounded",
+      "he_text": "האם הסדרה a_n=(-1)^n חסומה",
+      "id": "d8014943-6a36-4908-9aca-2923cf28452e",
+    },
+    {
+      "en_text": "Does a geometric series with ratio 2 converge",
+      "he_text": "האם טור גאומטרי בעל מנה 2 מתכנס",
+      "id": "a98199ac-0f21-4702-bfd4-95fc2667313a",
     },
   ],
   "unitAnswer": [

--- a/prisma/seed/modules.seed.ts
+++ b/prisma/seed/modules.seed.ts
@@ -50,7 +50,11 @@ export const seedModules = async (
       'Sum Principle_Separation Principle':
         '27a0eab8-6102-4020-a147-b5cfee9a2d76',
       Permutation_Derangements: 'f1a2b3c4-d5e6-4789-a012-bcdef4567890',
-      'Number Systems_Matrix Algebra': '7314520e-de66-4e11-a0b6-5c251f34de4a',
+      'Number Systems_Linear Equations': 'e08f5dfb-a229-4805-a343-aeefd3e449dd',
+      'Linear Equations_Matrix Algebra': 'b4a907e5-c49a-4368-9c50-fd625540285f',
+      'Combinations_Probability Basics': 'e110371c-44f6-4715-b394-fe9b21e18155',
+      'Limits and Continuity_Sequences and Series':
+        '9959f18b-ffd8-4940-858b-da4aa984e5fb',
     };
     return relationshipMap[`${prerequisite}_${postrequisite}`] || '';
   };
@@ -76,8 +80,14 @@ export const seedModules = async (
         'cadb461d-ba7c-42e4-9abb-607047d2d4da',
       'f1a2b3c4-d5e6-4789-a012-bcdef4567890':
         'f438751a-ed5d-4ed6-a090-cd9dc508b844',
-      '7314520e-de66-4e11-a0b6-5c251f34de4a':
-        '5203fc27-3295-4d03-b405-ddc57c038289',
+      'e08f5dfb-a229-4805-a343-aeefd3e449dd':
+        'f7445a44-2587-4ecd-b96c-0fa5382ca2a8',
+      'b4a907e5-c49a-4368-9c50-fd625540285f':
+        '68c57ee8-118a-4008-92d7-119c35cf1a87',
+      'e110371c-44f6-4715-b394-fe9b21e18155':
+        '05d2eb85-aa70-48c8-8e6d-4657417a7a5b',
+      '9959f18b-ffd8-4940-858b-da4aa984e5fb':
+        'efe8c558-a765-474f-a471-ed1beda8bbfe',
     };
     return metadataMap[blockRelationshipId] || '';
   };
@@ -214,6 +224,9 @@ export const seedModules = async (
     Queues: 'b68ae937-37a8-4d10-95a6-89a7017694bc',
     'Hash Tables': 'c2781ae5-9358-4297-8db9-e6651f6f5cd8',
     'Binary Trees': 'f8c9d5e1-2a3b-4c6d-8e9f-1a2b3c4d5e6f',
+    'Linear Equations': 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    'Probability Basics': '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    'Sequences and Series': 'e82b0404-286d-42ee-89a9-e54776575d9f',
   };
 
   const modules = [
@@ -265,9 +278,15 @@ export const seedModules = async (
       courses: ['Calculus A', 'Infinitesimal Calculus 1'],
     },
     {
+      en_text: 'Linear Equations',
+      he_text: 'משוואות לינאריות',
+      prerequisite: 'Number Systems',
+      course: 'Topics in Mathematics for Social Sciences Students',
+    },
+    {
       en_text: 'Matrix Algebra',
       he_text: 'אלגברת מטריצות',
-      prerequisite: 'Number Systems',
+      prerequisite: 'Linear Equations',
       course: 'Topics in Mathematics for Social Sciences Students',
     },
     {
@@ -388,6 +407,13 @@ export const seedModules = async (
       he_text: 'חליפות',
       parent: 'Combinatorics',
       prerequisite: 'Multiplication Principle',
+      course: 'Discrete Mathematics',
+    },
+    {
+      en_text: 'Probability Basics',
+      he_text: 'יסודות ההסתברות',
+      parent: 'Combinatorics',
+      prerequisite: 'Combinations',
       course: 'Discrete Mathematics',
     },
     {
@@ -637,6 +663,12 @@ export const seedModules = async (
       en_text: 'Limits and Continuity',
       he_text: 'גבולות ורציפות',
       courses: ['Calculus A', 'Infinitesimal Calculus 1'],
+    },
+    {
+      en_text: 'Sequences and Series',
+      he_text: 'סדרות וטורים',
+      prerequisite: 'Limits and Continuity',
+      course: 'Infinitesimal Calculus 1',
     },
     {
       en_text: 'Differentiation Techniques',

--- a/prisma/seed/questions.consts.ts
+++ b/prisma/seed/questions.consts.ts
@@ -5279,4 +5279,915 @@ export const QUESTIONS: QuestionSeedData[] = [
       },
     ],
   },
+  // Linear Equations module questions
+  {
+    id: 'e44492b0-ba38-425a-9b26-f6187cfac406',
+    translationId: '307b002b-ed58-4612-bd5e-9d189ff11db0',
+    text: {
+      en_text: 'Is x=2 a solution to 3x-6=0',
+      he_text: 'האם x=2 הוא פתרון למשוואה 3x-6=0',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    answers: [
+      {
+        id: '5fad5fa4-366f-4cc4-8faf-0f41d8d6223c',
+        selectAnswers: [
+          {
+            id: '24dc16f4-a328-4305-a786-9f73171eed8d',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: 'a42f894e-9fe5-4c03-a419-41a7d959405e',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '44bcfec5-15f7-4e6b-93e6-c2d218a5d958',
+    translationId: 'b3a07885-f515-4a33-ac10-5c92695d0172',
+    text: {
+      en_text: 'Is x=4 a solution to 2x+1=9',
+      he_text: 'האם x=4 הוא פתרון למשוואה 2x+1=9',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    answers: [
+      {
+        id: '8c3bc0e0-8a87-4de6-a786-186752f42cf9',
+        selectAnswers: [
+          {
+            id: 'c811f253-22a5-49cf-a306-6a7187e1268d',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '57303f04-1655-4a3e-9273-0d4cc31b2d7a',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'c66f213d-d82d-4487-bd84-fcc16c42bc12',
+    translationId: 'b84aaec3-5374-460e-abc7-dd26801acc97',
+    text: {
+      en_text: 'Is x=1 a solution to 5x+2=12',
+      he_text: 'האם x=1 הוא פתרון למשוואה 5x+2=12',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    answers: [
+      {
+        id: '4782ab64-8d89-4728-8869-9183fc7595bc',
+        selectAnswers: [
+          {
+            id: '42c56834-ab7d-4073-9e57-8c64c73b0f66',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: 'e6d22fcd-467f-4f41-8cad-8b187a59833d',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '83ec1df6-61b0-4f0f-b1a0-85868f36504a',
+    translationId: '9ebf3fd4-4f97-42fb-aef5-a5c133c95c09',
+    text: {
+      en_text: 'Is x=3 a solution to x/2-3=1',
+      he_text: 'האם x=3 הוא פתרון למשוואה x/2-3=1',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    answers: [
+      {
+        id: '7e089be2-446c-4b15-b47a-0d02300c757d',
+        selectAnswers: [
+          {
+            id: 'e6010ee7-aa76-4b8d-a2ee-5876bd24f4de',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: '89e809d3-0ea1-44ff-bf80-52073f34a4ea',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'a3d0274f-e899-4cb9-8f51-dd8a70c3da11',
+    translationId: '4e5741bc-dbe6-4590-913f-9926f6adcfe7',
+    text: {
+      en_text: 'Is x=3 and y=2 a solution to system x+y=5 and x-y=1',
+      he_text: 'האם x=3 ו y=2 הם פתרון למערכת x+y=5 ו x-y=1',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    answers: [
+      {
+        id: '5652948d-7d8b-44a8-bb1e-f38ac1277fe6',
+        selectAnswers: [
+          {
+            id: 'a8bb93d0-b1e5-4202-96db-c0c25279a755',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '10772a06-459b-4542-b8b1-01a4b3041a62',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'f947f030-47fe-4fa2-8f8f-ac491e4870f9',
+    translationId: 'daaefdba-936f-43b0-8fca-e5a0000f7ef2',
+    text: {
+      en_text: 'Is x=1 and y=1 a solution to system 2x+3y=6 and x-y=0',
+      he_text: 'האם x=1 ו y=1 הם פתרון למערכת 2x+3y=6 ו x-y=0',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    answers: [
+      {
+        id: '3a13ca7b-a014-4da2-8037-c76387872414',
+        selectAnswers: [
+          {
+            id: '71113790-1d76-4453-9fce-46033d3d4584',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: '9b98199a-84f5-4b90-882f-ed5a0b811868',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'a6537faa-4599-471a-952b-6a6353678eca',
+    translationId: 'adb534c9-ed46-4cac-b3a2-3bb5bac43fda',
+    text: {
+      en_text: 'Is x=1 a solution to 7x-4=3',
+      he_text: 'האם x=1 הוא פתרון למשוואה 7x-4=3',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    answers: [
+      {
+        id: 'f73fb1ad-460f-4e00-8952-977e77809cfb',
+        selectAnswers: [
+          {
+            id: '74880440-3546-43f7-8c59-93ddfd394e4a',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '71774e2a-4d52-4f57-9fe7-7bbf6d7d528c',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '230b27d3-deb0-4205-a6ed-e4ee00245157',
+    translationId: '1e25b879-86db-44e8-a04a-00d9dabe0a43',
+    text: {
+      en_text: 'Is x=0 a solution to 4x+5=5',
+      he_text: 'האם x=0 הוא פתרון למשוואה 4x+5=5',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    answers: [
+      {
+        id: '87719a18-8617-4c62-83c1-f6f5426ae9ea',
+        selectAnswers: [
+          {
+            id: '861aa05c-8a31-4999-9741-49abbfe518dc',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: 'fae7cdd1-68c2-4c11-9fcb-71cb321cb6a1',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '3c26a434-840a-4879-9d26-ffe43a40cbb9',
+    translationId: 'c517c697-0854-4307-931b-0d4d24e3f568',
+    text: {
+      en_text: 'Is x=1 and y=0 a solution to system x+y=1 and 2x+2y=2',
+      he_text: 'האם x=1 ו y=0 הם פתרון למערכת x+y=1 ו 2x+2y=2',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    answers: [
+      {
+        id: 'd01d38a3-70a2-43c6-b504-9b362ee50a9f',
+        selectAnswers: [
+          {
+            id: 'b370c78d-4d5f-4e66-8abc-4f70256a10d7',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '0004fa8d-c559-40b2-a0dc-dfce6e10951e',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '6a48d3d3-0b58-4852-a500-9eb907a8bb19',
+    translationId: 'c4547ab8-2327-48e1-86ca-ece2f0df0e8d',
+    text: {
+      en_text: 'Is x=1/3 a solution to 6x-2=1',
+      he_text: 'האם x=1/3 הוא פתרון למשוואה 6x-2=1',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'f91d2e2e-3fc8-45b5-ae64-e08a7d075e24',
+    answers: [
+      {
+        id: 'f35d4445-a478-4fa6-97d3-60f17a6190e8',
+        selectAnswers: [
+          {
+            id: '9a6be0f4-3c17-4730-8701-20740e1f9246',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: 'f5ffc3b2-ad40-45c0-b9a2-2659d17558fb',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
+
+  // Probability Basics module questions
+  {
+    id: '17b109bc-907c-407a-8f72-d66076911a70',
+    translationId: '8d3a08b5-5065-4cb7-8630-cc2f6cc13b53',
+    text: {
+      en_text: 'In a fair coin toss is probability of heads 0.5',
+      he_text: 'בהטלת מטבע הוגנת האם ההסתברות לצד עץ היא 0.5',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    answers: [
+      {
+        id: '186d685c-6c3e-4447-b414-51f0bdbfe074',
+        selectAnswers: [
+          {
+            id: '6ffc1d31-f56c-4306-83ec-575a0c81561a',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: 'cf2b20d6-8dfa-4671-8944-35d1cf4a46f1',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '1d982e83-fe47-4a63-9cee-d981e4c4904d',
+    translationId: '9e6be0ca-8822-433b-9434-25faebe6ff2a',
+    text: {
+      en_text: 'Is probability of rolling a 7 on a six sided die 1/6',
+      he_text: 'האם ההסתברות לגלגל 7 בקובייה בעלת שש פאות היא 1/6',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    answers: [
+      {
+        id: '8165efb7-2594-4108-a313-648c51f24974',
+        selectAnswers: [
+          {
+            id: '72054dce-01e8-4734-b93a-305fa5f133e6',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: '679b7464-83db-4ebd-a1c2-2a9a2e3d9d91',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'f298ba0b-62c1-4b53-9a75-7945e2f029f6',
+    translationId: '7bcb583d-015a-48bd-974f-d7ad92258dca',
+    text: {
+      en_text:
+        'For two independent events each with probability 0.5 is probability that both occur 0.25',
+      he_text:
+        'עבור שני אירועים בלתי תלויים שכל אחד בעל הסתברות 0.5 האם ההסתברות ששניהם יקרו היא 0.25',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    answers: [
+      {
+        id: '4b7ba131-4821-47e9-9f3d-512d6ca3eae2',
+        selectAnswers: [
+          {
+            id: '545c796b-4adf-4b2c-82e7-c2649d3e71fd',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '0860ccbb-8185-4584-a436-4d91d829fd1c',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'a8441874-6a87-4499-ae41-c82e792136ba',
+    translationId: '742b4b5c-01c1-4429-9956-2cb32f0171f6',
+    text: {
+      en_text: 'Is probability of drawing an ace from a standard deck 1/13',
+      he_text: 'האם ההסתברות לשלוף אס מחפיסת קלפים רגילה היא 1/13',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    answers: [
+      {
+        id: '43110d10-df5b-41ed-bde9-5ed222a9ef65',
+        selectAnswers: [
+          {
+            id: 'e303821c-ae24-4691-8cb9-b214a5e6a9bd',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '7493a3b8-e2f1-44d1-8e3c-005f52e1186e',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'fdaa8909-b6be-46b8-a2e0-60cac2bf0eb8',
+    translationId: '55331a85-439b-4bd0-ac2e-81cb5bc530f2',
+    text: {
+      en_text:
+        'Are events with probabilities 0.3 and 0.8 always mutually exclusive',
+      he_text: 'האם אירועים בעלי הסתברויות 0.3 ו 0.8 תמיד זרים',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    answers: [
+      {
+        id: '5ba2beda-b159-4672-bf66-50c9dbb4efea',
+        selectAnswers: [
+          {
+            id: '9748f334-6bec-406b-bd5b-c65ac78eaa32',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: '1247e41b-359d-4310-b222-09cd08bf1753',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'c3f99998-cb6c-4b3d-ad3e-2bcf2f257069',
+    translationId: '8bae3b74-c8c6-45ae-8c81-1165321012e0',
+    text: {
+      en_text: 'Is expected value of a fair six sided die 3.5',
+      he_text: 'האם התוחלת של קובייה הוגנת בעלת שש פאות היא 3.5',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    answers: [
+      {
+        id: 'c0907d7f-180a-4592-b68f-ed84ab599764',
+        selectAnswers: [
+          {
+            id: 'ad93ee2e-3e0a-4792-9d80-8c53ad3d8a42',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '24fb651d-dd05-4fdd-ae8a-9e2eeb37ba22',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '2a2fe409-b5b6-4bc8-9c21-8248d9cd020b',
+    translationId: 'b3558a47-7c4b-42a7-a82e-872531ede471',
+    text: {
+      en_text: 'Is variance of a fair six sided die 35/12',
+      he_text: 'האם השונות של קובייה הוגנת בעלת שש פאות היא 35/12',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    answers: [
+      {
+        id: '9a522513-e75a-4d26-ab9b-7fbb0b954f53',
+        selectAnswers: [
+          {
+            id: '81d8456f-416e-4e8b-a679-e5f6ac581e09',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: 'aa39cdb8-a09d-4fdb-9c07-c0bebf8110c2',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ce3ae121-e61b-4c92-a9ea-02072a962772',
+    translationId: '30e153ce-be8a-4999-83db-08491ca78a16',
+    text: {
+      en_text:
+        'Is probability of at least one tail in two fair coin tosses 0.75',
+      he_text: 'האם ההסתברות לפחות פלי אחד בשתי הטלות מטבע הוגנות היא 0.75',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    answers: [
+      {
+        id: '50c54597-21b9-4e8a-b6bb-65a2957d5d6d',
+        selectAnswers: [
+          {
+            id: '31096318-9abf-4793-9b59-dc1ad562dc66',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '161c7349-896a-4481-9771-2334ee247227',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '0d4204af-0ad5-4448-8d97-ad3b023fe9ed',
+    translationId: 'f9aa190e-6d9e-4c57-aa90-f40c605d7863',
+    text: {
+      en_text:
+        'Is probability that a randomly chosen day of the week is weekend 2/7',
+      he_text: 'האם ההסתברות שיום בשבוע הנבחר באקראי הוא סוף שבוע היא 2/7',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    answers: [
+      {
+        id: '59f4ca8f-034c-4a0c-ae07-e4789177ba4a',
+        selectAnswers: [
+          {
+            id: 'a87999c9-7cf6-48a1-b53e-040a19c373ab',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '95ff00d1-1719-43eb-bc4a-4c467316b659',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '38c3828e-444f-4770-9f4c-4910bb54cc0a',
+    translationId: '98d14525-2829-493d-ba8b-7a3c3981deb9',
+    text: {
+      en_text:
+        'If event A has probability 0.4 is probability of its complement 0.7',
+      he_text: 'אם לאירוע A הסתברות 0.4 האם להשלמתו הסתברות 0.7',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: '7496bad2-981e-4ac5-b464-788c4fc0d118',
+    answers: [
+      {
+        id: '71f7b18a-536e-468b-9522-526fa1940f37',
+        selectAnswers: [
+          {
+            id: 'f8d95ff4-7ab2-48d2-867d-8090ae357173',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: 'ad0a06ed-81d1-47bd-bea9-bd7429602f0d',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
+
+  // Sequences and Series module questions
+  {
+    id: '1c5b70f1-c7ef-4669-9cdc-97138ecba701',
+    translationId: '53ee56a0-ce58-498e-9eab-5d4b5979655b',
+    text: {
+      en_text: 'Does geometric series sum from n=0 of (1/2)^n converge to 2',
+      he_text: 'האם הטור הגאומטרי Σ(1/2)^n מ n=0 מתכנס ל 2',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'e82b0404-286d-42ee-89a9-e54776575d9f',
+    answers: [
+      {
+        id: '29ece213-9e2e-4dc1-a78b-b52959e63ca1',
+        selectAnswers: [
+          {
+            id: '9bec624b-6451-4256-8792-cff58f73bf09',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '456bfa13-2fb4-4cd8-9b1e-2b961231b297',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '8ea1c704-ecae-4555-b5ed-a8e9fc6e99e5',
+    translationId: '4629eb56-9988-4784-9527-f01cc8b2b0a8',
+    text: {
+      en_text: 'Is the series Σ 1/n convergent',
+      he_text: 'האם הטור Σ 1/n מתכנס',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'e82b0404-286d-42ee-89a9-e54776575d9f',
+    answers: [
+      {
+        id: 'cbb0a466-8561-47f4-a045-3da90c50ff3e',
+        selectAnswers: [
+          {
+            id: 'dc6c4de3-7fd3-4a61-bf11-3d27ad498a9c',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: '5eeebe56-0a33-4f87-9f69-7a02ef31370a',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '4a530557-7254-4fbd-96b7-770071376510',
+    translationId: 'c9848308-6852-4a3c-ab16-649fae324e55',
+    text: {
+      en_text: 'Does the sequence a_n=1/n converge to 0',
+      he_text: 'האם הסדרה a_n=1/n מתכנסת ל 0',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'e82b0404-286d-42ee-89a9-e54776575d9f',
+    answers: [
+      {
+        id: 'cdc6ebaf-cc52-46a7-a029-4f15c7ba28b6',
+        selectAnswers: [
+          {
+            id: 'e14e5f47-1629-4f25-969b-959379195adf',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '34c203ca-c140-4b34-9ecc-4b125aba9999',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'c66df6bb-f651-4d90-9262-521d952b4d80',
+    translationId: 'fdeed27d-2ead-4743-b772-545a7585c2ab',
+    text: {
+      en_text: 'Is the series Σ(-1)^n convergent',
+      he_text: 'האם הטור Σ(-1)^n מתכנס',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'e82b0404-286d-42ee-89a9-e54776575d9f',
+    answers: [
+      {
+        id: '042d79cb-dd8d-49b4-8149-6f2bbc0decce',
+        selectAnswers: [
+          {
+            id: '33de3f3e-6bac-4ec7-aeec-2fdedf294c2b',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: '6e6aee5d-dec7-4b81-838c-ac63991c7c73',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '059f0be9-0812-4ae8-8ae9-5789b1a45227',
+    translationId: 'af2d2a04-bf10-4cad-bbd1-8383ff2bd981',
+    text: {
+      en_text: 'Is the sequence a_n=n^2 bounded',
+      he_text: 'האם הסדרה a_n=n^2 חסומה',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'e82b0404-286d-42ee-89a9-e54776575d9f',
+    answers: [
+      {
+        id: '39aa6731-c5df-4b4e-ab6a-2fb4a047f24f',
+        selectAnswers: [
+          {
+            id: '3920f0a9-1fd3-4629-8759-7df269d9cb44',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: 'bc57fc1f-52fa-43e5-aa96-5de80301cf60',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'ad3b3737-f005-421a-a007-bd113aa559bb',
+    translationId: 'bb6e2d5d-ed1e-46b5-a016-d1a1b21053eb',
+    text: {
+      en_text: 'Does the series Σ1/n^2 converge',
+      he_text: 'האם הטור Σ1/n^2 מתכנס',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'e82b0404-286d-42ee-89a9-e54776575d9f',
+    answers: [
+      {
+        id: '99bf073a-6207-456d-bc9f-4a23a37f03f3',
+        selectAnswers: [
+          {
+            id: '93d9a850-ac81-4bfd-8e18-361a64fa1bb3',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '7f8245be-052d-4c7e-85be-bd0d5c4698ae',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '4a7a367e-3cfa-43a3-a851-94ba3116228e',
+    translationId: '8a8a4611-353d-4d9f-a19c-674dd54c68b8',
+    text: {
+      en_text: 'Is limit of sequence (1+1/n)^n equal to e',
+      he_text: 'האם הגבול של הסדרה (1+1/n)^n שווה ל e',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'e82b0404-286d-42ee-89a9-e54776575d9f',
+    answers: [
+      {
+        id: 'cb017d46-0391-4fd3-84af-5a6a65936098',
+        selectAnswers: [
+          {
+            id: '472d8f7b-d7b3-4bf9-a8f0-6bc8d23ea702',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: 'e8642c90-4928-460d-9c03-12c5f1bc633b',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '94282b4f-cb55-4199-ab72-c6ca765e601d',
+    translationId: 'f8318255-f2f3-4c00-b628-1ef1371a2376',
+    text: {
+      en_text: 'Does the series Σ(-1)^n/n converge',
+      he_text: 'האם הטור Σ(-1)^n/n מתכנס',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'e82b0404-286d-42ee-89a9-e54776575d9f',
+    answers: [
+      {
+        id: '9b3314a4-6a72-48b9-b9a6-af26f6e1659d',
+        selectAnswers: [
+          {
+            id: '4a77e6cb-8a6c-4013-be1d-727db847daca',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: '6fb0e471-3856-4a43-98a0-bba7b874a61e',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '209ebf99-ee8f-47cd-bf08-c98a252ea9bb',
+    translationId: 'd8014943-6a36-4908-9aca-2923cf28452e',
+    text: {
+      en_text: 'Is the sequence a_n=(-1)^n bounded',
+      he_text: 'האם הסדרה a_n=(-1)^n חסומה',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'e82b0404-286d-42ee-89a9-e54776575d9f',
+    answers: [
+      {
+        id: '04f341f3-de9a-46d1-9c5f-7f2d66f0dc6b',
+        selectAnswers: [
+          {
+            id: 'ac1dfdb9-80ea-42ae-891b-abfea2de6137',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: true,
+          },
+          {
+            id: 'e819dc5b-a820-4b86-8f41-a3787bbfac84',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: false,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'f9e86b69-1eb2-4f55-b8d4-7fb7c69ebd45',
+    translationId: 'a98199ac-0f21-4702-bfd4-95fc2667313a',
+    text: {
+      en_text: 'Does a geometric series with ratio 2 converge',
+      he_text: 'האם טור גאומטרי בעל מנה 2 מתכנס',
+    },
+    type: QuestionType.selection,
+    validationStatus: QuestionValidationStatus.ai_generated,
+    moduleId: 'e82b0404-286d-42ee-89a9-e54776575d9f',
+    answers: [
+      {
+        id: '6cab652c-5754-43f8-a552-8a137d76e50f',
+        selectAnswers: [
+          {
+            id: 'a56c3d51-d506-4d2e-a100-7c3b1cdad86d',
+            translationId: YES_TRANSLATION_ID,
+            text: { en_text: 'Yes', he_text: 'כן' },
+            isCorrect: false,
+          },
+          {
+            id: '79e0e7b5-88d4-4720-841b-23b20c08b9b8',
+            translationId: NO_TRANSLATION_ID,
+            text: { en_text: 'No', he_text: 'לא' },
+            isCorrect: true,
+          },
+        ],
+      },
+    ],
+  },
 ] satisfies QuestionSeedData[];

--- a/prisma/seed/translations.consts.ts
+++ b/prisma/seed/translations.consts.ts
@@ -3026,4 +3026,182 @@ In the Faculty of Arts, you're not just learning about the world — you're lear
     en_text: 'What is the determinant of the matrix [[5,2,1],[0,3,4],[2,1,0]]?',
     he_text: 'מהו הדטרמיננטה של המטריצה [[5,2,1],[0,3,4],[2,1,0]]?',
   },
+
+  // New module translations
+  {
+    id: '6e8bdbda-dffc-43bf-ba78-28fc024ac8b9',
+    en_text: 'Linear Equations',
+    he_text: 'משוואות לינאריות',
+  },
+  {
+    id: '4c1dfb25-25a7-4d2c-9d97-a6df46feb3f4',
+    en_text: 'Probability Basics',
+    he_text: 'יסודות ההסתברות',
+  },
+  {
+    id: 'b2bfed06-5f13-4c27-9611-b4cd1bbd258b',
+    en_text: 'Sequences and Series',
+    he_text: 'סדרות וטורים',
+  },
+
+  // Linear Equations questions
+  {
+    id: '307b002b-ed58-4612-bd5e-9d189ff11db0',
+    en_text: 'Is x=2 a solution to 3x-6=0',
+    he_text: 'האם x=2 הוא פתרון למשוואה 3x-6=0',
+  },
+  {
+    id: 'b3a07885-f515-4a33-ac10-5c92695d0172',
+    en_text: 'Is x=4 a solution to 2x+1=9',
+    he_text: 'האם x=4 הוא פתרון למשוואה 2x+1=9',
+  },
+  {
+    id: 'b84aaec3-5374-460e-abc7-dd26801acc97',
+    en_text: 'Is x=1 a solution to 5x+2=12',
+    he_text: 'האם x=1 הוא פתרון למשוואה 5x+2=12',
+  },
+  {
+    id: '9ebf3fd4-4f97-42fb-aef5-a5c133c95c09',
+    en_text: 'Is x=3 a solution to x/2-3=1',
+    he_text: 'האם x=3 הוא פתרון למשוואה x/2-3=1',
+  },
+  {
+    id: '4e5741bc-dbe6-4590-913f-9926f6adcfe7',
+    en_text: 'Is x=3 and y=2 a solution to system x+y=5 and x-y=1',
+    he_text: 'האם x=3 ו y=2 הם פתרון למערכת x+y=5 ו x-y=1',
+  },
+  {
+    id: 'daaefdba-936f-43b0-8fca-e5a0000f7ef2',
+    en_text: 'Is x=1 and y=1 a solution to system 2x+3y=6 and x-y=0',
+    he_text: 'האם x=1 ו y=1 הם פתרון למערכת 2x+3y=6 ו x-y=0',
+  },
+  {
+    id: 'adb534c9-ed46-4cac-b3a2-3bb5bac43fda',
+    en_text: 'Is x=1 a solution to 7x-4=3',
+    he_text: 'האם x=1 הוא פתרון למשוואה 7x-4=3',
+  },
+  {
+    id: '1e25b879-86db-44e8-a04a-00d9dabe0a43',
+    en_text: 'Is x=0 a solution to 4x+5=5',
+    he_text: 'האם x=0 הוא פתרון למשוואה 4x+5=5',
+  },
+  {
+    id: 'c517c697-0854-4307-931b-0d4d24e3f568',
+    en_text: 'Is x=1 and y=0 a solution to system x+y=1 and 2x+2y=2',
+    he_text: 'האם x=1 ו y=0 הם פתרון למערכת x+y=1 ו 2x+2y=2',
+  },
+  {
+    id: 'c4547ab8-2327-48e1-86ca-ece2f0df0e8d',
+    en_text: 'Is x=1/3 a solution to 6x-2=1',
+    he_text: 'האם x=1/3 הוא פתרון למשוואה 6x-2=1',
+  },
+
+  // Probability Basics questions
+  {
+    id: '8d3a08b5-5065-4cb7-8630-cc2f6cc13b53',
+    en_text: 'In a fair coin toss is probability of heads 0.5',
+    he_text: 'בהטלת מטבע הוגנת האם ההסתברות לצד עץ היא 0.5',
+  },
+  {
+    id: '9e6be0ca-8822-433b-9434-25faebe6ff2a',
+    en_text: 'Is probability of rolling a 7 on a six sided die 1/6',
+    he_text: 'האם ההסתברות לגלגל 7 בקובייה בעלת שש פאות היא 1/6',
+  },
+  {
+    id: '7bcb583d-015a-48bd-974f-d7ad92258dca',
+    en_text:
+      'For two independent events each with probability 0.5 is probability that both occur 0.25',
+    he_text:
+      'עבור שני אירועים בלתי תלויים שכל אחד בעל הסתברות 0.5 האם ההסתברות ששניהם יקרו היא 0.25',
+  },
+  {
+    id: '742b4b5c-01c1-4429-9956-2cb32f0171f6',
+    en_text: 'Is probability of drawing an ace from a standard deck 1/13',
+    he_text: 'האם ההסתברות לשלוף אס מחפיסת קלפים רגילה היא 1/13',
+  },
+  {
+    id: '55331a85-439b-4bd0-ac2e-81cb5bc530f2',
+    en_text:
+      'Are events with probabilities 0.3 and 0.8 always mutually exclusive',
+    he_text: 'האם אירועים בעלי הסתברויות 0.3 ו 0.8 תמיד זרים',
+  },
+  {
+    id: '8bae3b74-c8c6-45ae-8c81-1165321012e0',
+    en_text: 'Is expected value of a fair six sided die 3.5',
+    he_text: 'האם התוחלת של קובייה הוגנת בעלת שש פאות היא 3.5',
+  },
+  {
+    id: 'b3558a47-7c4b-42a7-a82e-872531ede471',
+    en_text: 'Is variance of a fair six sided die 35/12',
+    he_text: 'האם השונות של קובייה הוגנת בעלת שש פאות היא 35/12',
+  },
+  {
+    id: '30e153ce-be8a-4999-83db-08491ca78a16',
+    en_text: 'Is probability of at least one tail in two fair coin tosses 0.75',
+    he_text: 'האם ההסתברות לפחות פלי אחד בשתי הטלות מטבע הוגנות היא 0.75',
+  },
+  {
+    id: 'f9aa190e-6d9e-4c57-aa90-f40c605d7863',
+    en_text:
+      'Is probability that a randomly chosen day of the week is weekend 2/7',
+    he_text: 'האם ההסתברות שיום בשבוע הנבחר באקראי הוא סוף שבוע היא 2/7',
+  },
+  {
+    id: '98d14525-2829-493d-ba8b-7a3c3981deb9',
+    en_text:
+      'If event A has probability 0.4 is probability of its complement 0.7',
+    he_text: 'אם לאירוע A הסתברות 0.4 האם להשלמתו הסתברות 0.7',
+  },
+
+  // Sequences and Series questions
+  {
+    id: '53ee56a0-ce58-498e-9eab-5d4b5979655b',
+    en_text: 'Does geometric series sum from n=0 of (1/2)^n converge to 2',
+    he_text: 'האם הטור הגאומטרי Σ(1/2)^n מ n=0 מתכנס ל 2',
+  },
+  {
+    id: '4629eb56-9988-4784-9527-f01cc8b2b0a8',
+    en_text: 'Is the series Σ 1/n convergent',
+    he_text: 'האם הטור Σ 1/n מתכנס',
+  },
+  {
+    id: 'c9848308-6852-4a3c-ab16-649fae324e55',
+    en_text: 'Does the sequence a_n=1/n converge to 0',
+    he_text: 'האם הסדרה a_n=1/n מתכנסת ל 0',
+  },
+  {
+    id: 'fdeed27d-2ead-4743-b772-545a7585c2ab',
+    en_text: 'Is the series Σ(-1)^n convergent',
+    he_text: 'האם הטור Σ(-1)^n מתכנס',
+  },
+  {
+    id: 'af2d2a04-bf10-4cad-bbd1-8383ff2bd981',
+    en_text: 'Is the sequence a_n=n^2 bounded',
+    he_text: 'האם הסדרה a_n=n^2 חסומה',
+  },
+  {
+    id: 'bb6e2d5d-ed1e-46b5-a016-d1a1b21053eb',
+    en_text: 'Does the series Σ1/n^2 converge',
+    he_text: 'האם הטור Σ1/n^2 מתכנס',
+  },
+  {
+    id: '8a8a4611-353d-4d9f-a19c-674dd54c68b8',
+    en_text: 'Is limit of sequence (1+1/n)^n equal to e',
+    he_text: 'האם הגבול של הסדרה (1+1/n)^n שווה ל e',
+  },
+  {
+    id: 'f8318255-f2f3-4c00-b628-1ef1371a2376',
+    en_text: 'Does the series Σ(-1)^n/n converge',
+    he_text: 'האם הטור Σ(-1)^n/n מתכנס',
+  },
+  {
+    id: 'd8014943-6a36-4908-9aca-2923cf28452e',
+    en_text: 'Is the sequence a_n=(-1)^n bounded',
+    he_text: 'האם הסדרה a_n=(-1)^n חסומה',
+  },
+  {
+    id: 'a98199ac-0f21-4702-bfd4-95fc2667313a',
+    en_text: 'Does a geometric series with ratio 2 converge',
+    he_text: 'האם טור גאומטרי בעל מנה 2 מתכנס',
+  },
 ];


### PR DESCRIPTION
## Summary
- add Linear Equations, Probability Basics, and Sequences and Series modules
- seed 30 new yes/no questions across the new modules
- wire up deterministic prerequisites and relationships

## Testing
- `pnpm vitest run prisma/seed/seed.snapshot.spec.ts --update`
- `pnpm test:seed`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68997c19d8d88332a54f3b9dbca9ab4d