### PR TITLE
Add Electrical Engineering degree for Tel Aviv University

### DIFF
--- a/prisma/seed/__snapshots__/seed.snapshot.spec.ts.snap
+++ b/prisma/seed/__snapshots__/seed.snapshot.spec.ts.snap
@@ -2513,6 +2513,11 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "translationId": "63e95b0b-85de-4c54-b6af-face80091bb4",
       "universityId": "92e73fb7-96de-45e4-aff3-4ca7b89be16c",
     },
+    {
+      "id": "fe63f747-f7c8-4c63-bb5b-904f503cd23e",
+      "translationId": "25800af4-b146-4cd0-83c0-dc64729dcc7f",
+      "universityId": "42e9a858-0a22-482d-ab1d-65f7a00ceb4c",
+    },
   ],
   "faculty": [
     {
@@ -7709,6 +7714,11 @@ exports[`seed snapshot > saves seeded data snapshot 1`] = `
       "en_text": "Engineering",
       "he_text": "הנדסה",
       "id": "369f5ce8-05f1-4d30-820e-baeb8bfb4e93",
+    },
+    {
+      "en_text": "Electrical Engineering",
+      "he_text": "הנדסת חשמל",
+      "id": "25800af4-b146-4cd0-83c0-dc64729dcc7f",
     },
     {
       "en_text": "Arts",

--- a/prisma/seed/degree.seed.ts
+++ b/prisma/seed/degree.seed.ts
@@ -3,6 +3,7 @@ import { SeedCache } from './cache';
 import {
   THE_COLLEGE_OF_MANAGEMENT_ACADEMIC_STUDIES_EN_NAME,
   THE_OPEN_UNIVERSITY_OF_ISRAEL_EN_NAME,
+  TEL_AVIV_UNIVERSITY_EN_NAME,
 } from './universities.consts';
 import { degreeCourses } from './degrees.consts.seed';
 
@@ -42,6 +43,11 @@ export const degreeSeeds: DegreeSeed[] = [
     id: 'c7a1e2b2-8e2d-4c1a-9e2a-1a2b3c4d5e6f',
     enText: 'Computer Science',
     university: THE_COLLEGE_OF_MANAGEMENT_ACADEMIC_STUDIES_EN_NAME,
+  },
+  {
+    id: 'fe63f747-f7c8-4c63-bb5b-904f503cd23e',
+    enText: 'Electrical Engineering',
+    university: TEL_AVIV_UNIVERSITY_EN_NAME,
   },
 ];
 

--- a/prisma/seed/degrees.consts.seed.ts
+++ b/prisma/seed/degrees.consts.seed.ts
@@ -1,6 +1,7 @@
 import {
   THE_COLLEGE_OF_MANAGEMENT_ACADEMIC_STUDIES_EN_NAME,
   THE_OPEN_UNIVERSITY_OF_ISRAEL_EN_NAME,
+  TEL_AVIV_UNIVERSITY_EN_NAME,
 } from './universities.consts';
 
 const faculties = {
@@ -80,5 +81,8 @@ export const degreeCourses = {
       'Calculus B',
       'Topics in Applied Mathematics',
     ],
+  },
+  [TEL_AVIV_UNIVERSITY_EN_NAME]: {
+    'Electrical Engineering': ['Linear Algebra 1'],
   },
 };

--- a/prisma/seed/translations.consts.ts
+++ b/prisma/seed/translations.consts.ts
@@ -98,6 +98,11 @@ export const TRANSLATIONS: TranslationSeed[] = [
     he_text: 'הנדסה',
   },
   {
+    id: '25800af4-b146-4cd0-83c0-dc64729dcc7f',
+    en_text: 'Electrical Engineering',
+    he_text: 'הנדסת חשמל',
+  },
+  {
     id: '1b1daa8c-4cc3-4715-b876-908c29dba6a4',
     en_text: 'Arts',
     he_text: 'אמנויות',


### PR DESCRIPTION
## Summary
- add Electrical Engineering translation
- map Electrical Engineering degree with sample course for Tel Aviv University
- seed Electrical Engineering degree for Tel Aviv University

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689b59b6492c8332af196f06f4965dfd