### PR TITLE
chore(claude): wire up block-no-verify PreToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,5 +35,27 @@
     ],
     "deny": [],
     "ask": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__github__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Adds the [`block-no-verify`](https://www.npmjs.com/package/block-no-verify) Claude Code hook to `.claude/settings.json`, so coding agents working in this repo cannot bypass its git hooks.

## What it does

`block-no-verify` is a `PreToolUse` hook that inspects a tool call before it runs and blocks it if it would skip the local hook chain — `git ... --no-verify`, `core.hooksPath` overrides, hook-manager disable env vars (`HUSKY=0`, `LEFTHOOK=0`, ...), and GitHub MCP tool calls that write straight through the GitHub API.

## The change

One file, config only. Two matchers, exactly as the package README documents:

| Matcher | Covers |
| --- | --- |
| `Bash` | shell commands (`--no-verify`, `core.hooksPath`) |
| `mcp__github__.*` | direct-to-API writes via the GitHub MCP server |

The existing `permissions` block is untouched — the `hooks` key is merged alongside it.

## Verification

Ran the binary against both a blocked and an allowed command:

```
$ echo '{"tool_name":"Bash","tool_input":{"command":"git commit --no-verify -m x"}}' | npx block-no-verify
{"decision":"block","reason":"BLOCKED: --no-verify flag is not allowed with git commit. ..."}
exit=2

$ echo '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}' | npx block-no-verify
{}
exit=0
```

## Note on `npx` vs `pnpm exec`

The README suggests installing `block-no-verify` as a dev dependency and invoking it via `pnpm exec`. This PR uses `npx` instead and adds no dependency, because regenerating `pnpm-lock.yaml` here also pulled in an unrelated `eslint-config-agent` 1.6.0 → 1.9.3 bump (the committed lockfile is behind the `^1.8.2` specifier in `package.json`). Keeping this PR config-only avoids mixing that in. Happy to switch to a pinned dev dependency in a follow-up once the lockfile drift is resolved separately.

---

🤖 This PR was opened by the moadim routine **"Add block-no-verify hook to a repo"**, running on [Claude Code](https://claude.com/claude-code).